### PR TITLE
Simplify ref.read

### DIFF
--- a/examples/marvel/lib/main.dart
+++ b/examples/marvel/lib/main.dart
@@ -28,7 +28,7 @@ final charactersProvider = StreamProvider((ref) async* {
   var offset = 0;
   var allCharacters = const <Character>[];
 
-  final repository = ref.read(repositoryProvider).value;
+  final repository = ref.dependOn(repositoryProvider).value;
 
   do {
     final res = await repository.fetchCharacters(offset: offset);

--- a/examples/marvel/lib/marvel.dart
+++ b/examples/marvel/lib/marvel.dart
@@ -57,7 +57,7 @@ class MarvelRepository {
     Map<String, Object> queryParameters,
   }) {
     return Result.guardFuture(() async {
-      final configs = await _ref.read(configurationsProvider).future;
+      final configs = await _ref.dependOn(configurationsProvider).value;
 
       final timestamp = _getCurrentTimestamp();
       final hash = md5

--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.0
+
+- `ref.read` is renamed as `ref.dependOn`
+- Deprecated `ref.dependOn(streamProvider).stream` and `ref.dependOn(futureProvider).future`
+  in favor of a universal `ref.dependOn(provider).value`.
+- added `ref.read(provider)`, syntax sugar for `ref.dependOn(provider).value`.
+
 # 0.1.0
 
 Initial release

--- a/packages/flutter_riverpod/example
+++ b/packages/flutter_riverpod/example
@@ -1,1 +1,0 @@
-../../examples/counter

--- a/packages/flutter_riverpod/example/.gitignore
+++ b/packages/flutter_riverpod/example/.gitignore
@@ -1,0 +1,44 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Exceptions to above rules.
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/packages/flutter_riverpod/example/.metadata
+++ b/packages/flutter_riverpod/example/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: 94b7ff241e6e5445b7f30215a777eb4971311797
+  channel: master
+
+project_type: app

--- a/packages/flutter_riverpod/example/analysis_options.yaml
+++ b/packages/flutter_riverpod/example/analysis_options.yaml
@@ -1,0 +1,17 @@
+include: ../../../analysis_options.yaml
+linter:
+  rules:
+    # Useful for packages but not for apps
+    type_annotate_public_apis: false
+
+    # generates false positives
+    close_sinks: false
+
+    # Our example actually wants to print to the console
+    avoid_print: false
+
+    # Not necessary for examples
+    public_member_api_docs: false
+
+    # Not necessary for examples
+    use_key_in_widget_constructors: false

--- a/packages/flutter_riverpod/example/lib/main.dart
+++ b/packages/flutter_riverpod/example/lib/main.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+// A Counter example implemented with riverpod
+
+void main() {
+  runApp(
+    // Adding ProviderScope enables Riverpod for the entire project
+    const ProviderScope(child: MyApp()),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home: Home());
+  }
+}
+
+/// Providers are declared globally and specifies how to create a state
+final counterProvider = StateProvider((ref) => 0);
+
+class Home extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Counter example')),
+      body: Center(
+        // Consumer is a widget that allows you reading providers.
+        // You could also use the hook "useProvider" if you uses flutter_hooks
+        child: Consumer((context, read) {
+          final count = read(counterProvider).state;
+          return Text('$count');
+        }),
+      ),
+      floatingActionButton: FloatingActionButton(
+        // The read method is an utility to read a provider without listening to it
+        onPressed: () => counterProvider.read(context).state++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/flutter_riverpod/example/pubspec.yaml
+++ b/packages/flutter_riverpod/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: counter
 description: A new Flutter project.
 
 publish_to: "none"
@@ -10,8 +10,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_riverpod:
+    path: ../../flutter_riverpod
+  riverpod:
+    path: ../../riverpod
   hooks_riverpod:
-    path: ..
+    path: ../../hooks_riverpod
+  cupertino_icons: ^0.1.3
 
 dev_dependencies:
   flutter_test:
@@ -23,7 +28,7 @@ dependency_overrides:
   riverpod:
     path: ../../riverpod
   hooks_riverpod:
-    path: ..
+    path: ../../hooks_riverpod
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_riverpod/example/test/widget_test.dart
+++ b/packages/flutter_riverpod/example/test/widget_test.dart
@@ -1,0 +1,31 @@
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility that Flutter provides. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:counter/main.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  testWidgets('Counter increments smoke test', (tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+  });
+}

--- a/packages/flutter_riverpod/pubspec.yaml
+++ b/packages/flutter_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and being testable.
-version: 0.1.0
+version: 0.2.0
 homepage: https://riverpod.dev
 authors:
   - Remi Rousselet <darky12s@gmail.com>
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.14.12
-  riverpod: ^0.1.0
+  riverpod: ^0.2.0
   state_notifier: ^0.5.0
 
 dev_dependencies:

--- a/packages/flutter_riverpod/test/change_notifier_provider_test.dart
+++ b/packages/flutter_riverpod/test/change_notifier_provider_test.dart
@@ -3,6 +3,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('ChangeNotifierProviderDependency can be assigned to ProviderDependency',
+      () async {
+    final provider = ChangeNotifierProvider((ref) {
+      return ValueNotifier(0);
+    });
+    final owner = ProviderStateOwner();
+
+    // ignore: omit_local_variable_types
+    final ProviderDependency<ValueNotifier<int>> dep =
+        owner.ref.dependOn(provider);
+
+    await expectLater(dep.value.value, 0);
+  });
   test('family', () {
     final owner = ProviderStateOwner();
     final provider =

--- a/packages/flutter_riverpod/test/future_provider_test.dart
+++ b/packages/flutter_riverpod/test/future_provider_test.dart
@@ -168,8 +168,8 @@ void main() {
     var completed = false;
     final proxy = Provider<String>(
       (ref) {
-        final first = ref.read(futureProvider);
-        future = first.future
+        final first = ref.dependOn(futureProvider);
+        future = first.value
           ..then(
             (value) => completed = true,
             onError: (dynamic _) => completed = true,
@@ -430,8 +430,8 @@ void main() {
     final futureProvider = FutureProvider((_) async => 42);
 
     final futureProviderFamily = FutureProvider<int>((ref) async {
-      final other = ref.read(futureProvider);
-      return await other.future * 2;
+      final other = ref.dependOn(futureProvider);
+      return await other.value * 2;
     });
 
     await tester.pumpWidget(
@@ -460,7 +460,7 @@ void main() {
     final futureProvider = Provider((_) => 42);
 
     final futureProviderFamily = FutureProvider<int>((ref) async {
-      final other = ref.read(futureProvider);
+      final other = ref.dependOn(futureProvider);
       return other.value * 2;
     });
 
@@ -489,7 +489,7 @@ void main() {
     final futureProvider = Provider((_) => 42);
 
     final futureProviderFamily = FutureProvider<int>((ref) async {
-      final other = ref.read(futureProvider);
+      final other = ref.dependOn(futureProvider);
       return other.value * 2;
     });
 

--- a/packages/flutter_riverpod/test/provider_test.dart
+++ b/packages/flutter_riverpod/test/provider_test.dart
@@ -253,7 +253,7 @@ void main() {
         overrides: [
           provider2.overrideAs(
             Provider<int>((ref) {
-              final other = ref.read(provider);
+              final other = ref.dependOn(provider);
               return other.value * 2;
             }),
           ),
@@ -310,7 +310,7 @@ void main() {
     final provider = Provider((_) => 0);
 
     final provider1 = Provider((ref) {
-      final other = ref.read(provider);
+      final other = ref.dependOn(provider);
       return other.value.toString();
     });
 
@@ -331,15 +331,15 @@ void main() {
   testWidgets('provider1 chain', (tester) async {
     final first = Provider((_) => 1);
     final second = Provider<int>((ref) {
-      final other = ref.read(first);
+      final other = ref.dependOn(first);
       return other.value + 1;
     });
     final third = Provider<int>((ref) {
-      final other = ref.read(second);
+      final other = ref.dependOn(second);
       return other.value + 1;
     });
     final forth = Provider<int>((ref) {
-      final other = ref.read(third);
+      final other = ref.dependOn(third);
       return other.value + 1;
     });
 
@@ -359,15 +359,15 @@ void main() {
   testWidgets('overriden provider1 chain', (tester) async {
     final first = Provider((_) => 1);
     final second = Provider<int>((ref) {
-      final other = ref.read(first);
+      final other = ref.dependOn(first);
       return other.value + 1;
     });
     final third = Provider<int>((ref) {
-      final other = ref.read(second);
+      final other = ref.dependOn(second);
       return other.value + 1;
     });
     final forth = Provider<int>((ref) {
-      final other = ref.read(third);
+      final other = ref.dependOn(third);
       return other.value + 1;
     });
 
@@ -390,15 +390,15 @@ void main() {
   testWidgets('partial override provider1 chain', (tester) async {
     final first = Provider((_) => 1);
     final second = Provider<int>((ref) {
-      final other = ref.read(first);
+      final other = ref.dependOn(first);
       return other.value + 1;
     });
     final third = Provider<int>((ref) {
-      final other = ref.read(second);
+      final other = ref.dependOn(second);
       return other.value + 1;
     });
     final forth = Provider<int>((ref) {
-      final other = ref.read(third);
+      final other = ref.dependOn(third);
       return other.value + 1;
     });
 
@@ -427,7 +427,7 @@ void main() {
 
     // ignore: omit_local_variable_types
     final Provider<int> provider1 = Provider<int>((r) {
-      final first = r.read(provider);
+      final first = r.dependOn(provider);
       ref = r;
       firstState = first;
       return first.value * 2;

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and being testable.
-version: 0.1.0
+version: 0.2.0
 homepage: https://riverpod.dev
 authors:
   - Remi Rousselet <darky12s@gmail.com>
@@ -11,8 +11,8 @@ environment:
   sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
-  flutter_riverpod: ^0.1.0
-  riverpod: ^0.1.0
+  flutter_riverpod: ^0.2.0
+  riverpod: ^0.2.0
   flutter:
     sdk: flutter
   flutter_hooks: ^0.10.0

--- a/packages/hooks_riverpod/test/future_provider1_test.dart
+++ b/packages/hooks_riverpod/test/future_provider1_test.dart
@@ -8,8 +8,8 @@ void main() {
     final futureProvider = FutureProvider((_) async => 42);
 
     final futureProviderFamily = FutureProvider<int>((ref) async {
-      final other = ref.read(futureProvider);
-      return await other.future * 2;
+      final other = ref.dependOn(futureProvider);
+      return await other.value * 2;
     });
 
     await tester.pumpWidget(
@@ -38,7 +38,7 @@ void main() {
     final futureProvider = Provider((_) => 42);
 
     final futureProviderFamily = FutureProvider<int>((ref) async {
-      final other = ref.read(futureProvider);
+      final other = ref.dependOn(futureProvider);
       return other.value * 2;
     });
 
@@ -67,7 +67,7 @@ void main() {
     final futureProvider = Provider((_) => 42);
 
     final futureProviderFamily = FutureProvider<int>((ref) async {
-      final other = ref.read(futureProvider);
+      final other = ref.dependOn(futureProvider);
       return other.value * 2;
     });
 

--- a/packages/hooks_riverpod/test/future_provider_test.dart
+++ b/packages/hooks_riverpod/test/future_provider_test.dart
@@ -149,8 +149,8 @@ void main() {
     var completed = false;
     final proxy = Provider<String>(
       (ref) {
-        final first = ref.read(futureProvider);
-        future = first.future
+        final first = ref.dependOn(futureProvider);
+        future = first.value
           ..then(
             (value) => completed = true,
             onError: (dynamic _) => completed = true,

--- a/packages/hooks_riverpod/test/provider1_test.dart
+++ b/packages/hooks_riverpod/test/provider1_test.dart
@@ -13,7 +13,7 @@ void main() {
         overrides: [
           provider2.overrideAs(
             Provider<int>((ref) {
-              final other = ref.read(provider);
+              final other = ref.dependOn(provider);
               return other.value * 2;
             }),
           ),
@@ -68,7 +68,7 @@ void main() {
     final provider = Provider((_) => 0);
 
     final provider1 = Provider((ref) {
-      final other = ref.read(provider);
+      final other = ref.dependOn(provider);
       return other.value.toString();
     });
 
@@ -89,15 +89,15 @@ void main() {
   testWidgets('provider1 chain', (tester) async {
     final first = Provider((_) => 1);
     final second = Provider<int>((ref) {
-      final other = ref.read(first);
+      final other = ref.dependOn(first);
       return other.value + 1;
     });
     final third = Provider<int>((ref) {
-      final other = ref.read(second);
+      final other = ref.dependOn(second);
       return other.value + 1;
     });
     final forth = Provider<int>((ref) {
-      final other = ref.read(third);
+      final other = ref.dependOn(third);
       return other.value + 1;
     });
 
@@ -115,15 +115,15 @@ void main() {
   testWidgets('overriden provider1 chain', (tester) async {
     final first = Provider((_) => 1);
     final second = Provider<int>((ref) {
-      final other = ref.read(first);
+      final other = ref.dependOn(first);
       return other.value + 1;
     });
     final third = Provider<int>((ref) {
-      final other = ref.read(second);
+      final other = ref.dependOn(second);
       return other.value + 1;
     });
     final forth = Provider<int>((ref) {
-      final other = ref.read(third);
+      final other = ref.dependOn(third);
       return other.value + 1;
     });
 
@@ -144,15 +144,15 @@ void main() {
   testWidgets('partial override provider1 chain', (tester) async {
     final first = Provider((_) => 1);
     final second = Provider<int>((ref) {
-      final other = ref.read(first);
+      final other = ref.dependOn(first);
       return other.value + 1;
     });
     final third = Provider<int>((ref) {
-      final other = ref.read(second);
+      final other = ref.dependOn(second);
       return other.value + 1;
     });
     final forth = Provider<int>((ref) {
-      final other = ref.read(third);
+      final other = ref.dependOn(third);
       return other.value + 1;
     });
 

--- a/packages/hooks_riverpod/test/provider_builder_test.dart
+++ b/packages/hooks_riverpod/test/provider_builder_test.dart
@@ -13,7 +13,7 @@ void main() {
     ProviderDependency<int> firstState;
 
     final Provider<int> provider1 = Provider<int>((r) {
-      final first = r.read(provider);
+      final first = r.dependOn(provider);
       ref = r;
       firstState = first;
       return first.value * 2;

--- a/packages/riverpod/example/lib/main.dart
+++ b/packages/riverpod/example/lib/main.dart
@@ -34,7 +34,7 @@ final configurationProvider = FutureProvider((_) async {
 /// This will correctly wait until the configurations are available.
 final repositoryProvider = FutureProvider((ref) async {
   /// Reads the configurations from [configurationProvider]. This is type-safe.
-  final configs = await ref.read(configurationProvider).future;
+  final configs = await ref.dependOn(configurationProvider).value;
 
   final repository = Repository(configs);
   // Releases the resources when the provider is destroyed.
@@ -51,7 +51,7 @@ Future<void> main() async {
   final owner = ProviderStateOwner();
 
   /// Obtains the [Repository]. This will implicitly load [Configuration] too.
-  final repository = await owner.ref.read(repositoryProvider).future;
+  final repository = await owner.ref.dependOn(repositoryProvider).value;
 
   final comics = await repository.fetchComics();
   for (final comic in comics) {

--- a/packages/riverpod/lib/src/framework/base_provider.dart
+++ b/packages/riverpod/lib/src/framework/base_provider.dart
@@ -239,7 +239,7 @@ abstract class ProviderStateBase<Dependency extends ProviderDependencyBase,
 
   /// An implementation detail of [CircularDependencyError].
   ///
-  /// This handles the case where [ProviderReference.read] is called
+  /// This handles the case where [ProviderReference.dependOn] is called
   /// synchronously during the creation of the provider.
   ProviderBase _debugInitialDependOnRequest;
 
@@ -285,7 +285,7 @@ abstract class ProviderStateBase<Dependency extends ProviderDependencyBase,
   /// If [initState] throws, reading the provider will result in an exception.
   void initState();
 
-  /// Creates the object returned by [ProviderReference.read].
+  /// Creates the object returned by [ProviderReference.dependOn].
   Dependency createProviderDependency();
 
   /// Life-cycle for when [provider] was replaced with a new one.
@@ -296,7 +296,7 @@ abstract class ProviderStateBase<Dependency extends ProviderDependencyBase,
   @protected
   void didUpdateProvider(P oldProvider) {}
 
-  /// The implementation of [ProviderReference.read].
+  /// The implementation of [ProviderReference.dependOn].
   T read<T extends ProviderDependencyBase>(
     ProviderBase<T, Object> provider,
   ) {

--- a/packages/riverpod/lib/src/framework/framework.dart
+++ b/packages/riverpod/lib/src/framework/framework.dart
@@ -598,13 +598,13 @@ class ProviderOverride implements Override {
 /// Do not extend or implement.
 class Override {}
 
-/// A base class for objects returned by [ProviderReference.read].
+/// A base class for objects returned by [ProviderReference.dependOn].
 abstract class ProviderDependencyBase {}
 
 /// An empty implementation of [ProviderDependencyBase].
 class ProviderBaseDependencyImpl extends ProviderDependencyBase {}
 
-/// An error thrown when a call to [ProviderReference.read] leads
+/// An error thrown when a call to [ProviderReference.dependOn] leads
 /// to a provider depending on itself.
 ///
 /// Circular dependencies are both not supported for performance reasons
@@ -619,7 +619,7 @@ class CircularDependencyError extends Error {
 /// of the application.
 ///
 /// See also:
-/// - [read], a method that allows a provider to consume other providers.
+/// - [dependOn], a method that allows a provider to consume other providers.
 /// - [mounted], an utility to know whether the provider is still "alive" or not.
 /// - [onDispose], a method that allows performing a task when the provider is destroyed.
 /// - [Provider], an example of a provider that uses [ProviderReference].
@@ -655,7 +655,7 @@ class ProviderReference {
 
   /// Obtain another provider.
   ///
-  /// It is safe to call [read] multiple times with the same provider
+  /// It is safe to call [dependOn] multiple times with the same provider
   /// as parameter and is inexpensive to do so.
   ///
   /// Calling this method is O(1).
@@ -663,7 +663,7 @@ class ProviderReference {
   /// See also:
   ///
   /// - [Provider], explains in further detail how to use this method.
-  T read<T extends ProviderDependencyBase>(
+  T dependOn<T extends ProviderDependencyBase>(
     ProviderBase<T, Object> provider,
   ) {
     return _providerState.read(provider);

--- a/packages/riverpod/lib/src/framework/framework.dart
+++ b/packages/riverpod/lib/src/framework/framework.dart
@@ -668,4 +668,17 @@ class ProviderReference {
   ) {
     return _providerState.read(provider);
   }
+
+  /// Reads the value of a provider.
+  ///
+  /// This is syntax sugar for `ref.dependOn(provider).value`, avoiding
+  /// having to read `.value` on providers that expose such property.
+  ///
+  /// See also:
+  ///
+  /// - [dependOn], which reads a provider and returns a [ProviderDependencyBase]
+  ///   instead of a value directly.
+  T read<T>(ProviderBase<ProviderDependency<T>, Object> provider) {
+    return dependOn(provider).value;
+  }
 }

--- a/packages/riverpod/lib/src/future_provider/future_provider.dart
+++ b/packages/riverpod/lib/src/future_provider/future_provider.dart
@@ -10,10 +10,11 @@ import '../stream_provider/stream_provider.dart';
 part 'auto_dispose_future_provider.dart';
 
 /// The state of a [FutureProvider].
-class FutureProviderDependency<T> extends ProviderDependencyBase {
-  FutureProviderDependency._({@required this.future});
+class FutureProviderDependency<T> extends ProviderDependencyImpl<Future<T>> {
+  FutureProviderDependency._({@required this.future}) : super(future);
 
   /// The [Future] created by [FutureProvider].
+  @Deprecated('`future` will be removed in 0.3.0. Use `value` instead.')
   final Future<T> future;
 }
 
@@ -46,7 +47,7 @@ class FutureProvider<Res> extends AlwaysAliveProviderBase<
   /// Once an [AsyncValue.data]/[AsyncValue.error] was emitted, it is no longer
   /// possible to change the value exposed.
   ///
-  /// This will create a made up [Future] for [FutureProviderDependency.future].
+  /// This will create a made up [Future] for [ProviderDependency.value].
   Override debugOverrideWithValue(AsyncValue<Res> value) {
     ProviderOverride res;
     assert(() {

--- a/packages/riverpod/lib/src/provider/provider.dart
+++ b/packages/riverpod/lib/src/provider/provider.dart
@@ -127,7 +127,7 @@ class ProviderDependencyImpl<T> implements ProviderDependency<T> {
 /// final weatherProvider = FutureProvider((ref) async {
 ///   // We use `ref.read` to read another provider, and we pass it the provider
 ///   // that we want to consume. Here: cityProvider
-///   final city = ref.read(cityProvider).value;
+///   final city = ref.read(cityProvider);
 ///
 ///   // We can then use the result to do something based on the value of `cityProvider`.
 ///   return fetchWeather(city: city);
@@ -146,8 +146,8 @@ class ProviderDependencyImpl<T> implements ProviderDependency<T> {
 /// final countryProvider = Provider((ref) => 'England');
 ///
 /// final weatherProvider = Provider((ref) {
-///   final city = ref.read(cityProvider).value;
-///   final country = ref.read(countryProvider).value;
+///   final city = ref.read(cityProvider);
+///   final country = ref.read(countryProvider);
 ///
 ///   return Location(city: city, country: country);
 /// });
@@ -183,8 +183,8 @@ class ProviderDependencyImpl<T> implements ProviderDependency<T> {
 ///   final ProviderReference _ref;
 ///
 ///   String get label {
-///     final city = _ref.read(cityProvider).value;
-///     final country = _ref.read(countryProvider).value;
+///     final city = _ref.read(cityProvider);
+///     final country = _ref.read(countryProvider);
 ///     return '$city ($country)';
 ///   }
 /// }
@@ -314,7 +314,7 @@ class ProviderState<T>
 ///   ```dart
 ///   final repositoryProvider = ProviderFamily<String, FutureProvider<Configurations>>((ref, configurationsProvider) {
 ///     // Read a provider without knowing what that provider is.
-///     final configurations = await ref.read(configurationsProvider).future;
+///     final configurations = await ref.read(configurationsProvider);
 ///     return Repository(host: configurations.host);
 ///   });
 ///   ```

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose_state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose_state_notifier_provider.dart
@@ -66,7 +66,7 @@ class AutoDisposeStateNotifierStateProvider<T>
     extends AutoDisposeSetStateProvider<T> {
   AutoDisposeStateNotifierStateProvider._(this.notifierProvider)
       : super((ref) {
-          final notifier = ref.read(notifierProvider).value;
+          final notifier = ref.dependOn(notifierProvider).value;
 
           ref.onDispose(
             notifier.addListener((newValue) => ref.state = newValue),

--- a/packages/riverpod/lib/src/state_notifier_provider/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/state_notifier_provider.dart
@@ -65,7 +65,7 @@ extension StateNotifierStateProviderX<Value>
 class StateNotifierStateProvider<T> extends SetStateProvider<T> {
   StateNotifierStateProvider._(this.notifierProvider)
       : super((ref) {
-          final notifier = ref.read(notifierProvider).value;
+          final notifier = ref.dependOn(notifierProvider).value;
 
           ref.onDispose(
             notifier.addListener((newValue) => ref.state = newValue),

--- a/packages/riverpod/lib/src/state_provider.dart
+++ b/packages/riverpod/lib/src/state_provider.dart
@@ -27,8 +27,8 @@ class StateController<T> extends StateNotifier<T> {
 ///
 /// This is syntax sugar for [StateNotifierProvider] for simple values like enums
 /// or booleans.
-class StateProvider<T> extends AlwaysAliveProviderBase<ProviderDependencyBase,
-    StateController<T>> {
+class StateProvider<T> extends AlwaysAliveProviderBase<
+    ProviderDependency<StateController<T>>, StateController<T>> {
   /// Creates the initial value
   StateProvider(this._create, {String name}) : super(name);
 
@@ -38,8 +38,10 @@ class StateProvider<T> extends AlwaysAliveProviderBase<ProviderDependencyBase,
   _ProviderState<T> createState() => _ProviderState();
 }
 
-class _ProviderState<T> extends ProviderStateBase<ProviderDependencyBase,
-    StateController<T>, StateProvider<T>> {
+class _ProviderState<T> extends ProviderStateBase<
+    ProviderDependency<StateController<T>>,
+    StateController<T>,
+    StateProvider<T>> {
   @override
   StateController<T> state;
   VoidCallback _removeListener;
@@ -52,8 +54,8 @@ class _ProviderState<T> extends ProviderStateBase<ProviderDependencyBase,
   }
 
   @override
-  ProviderDependencyBase createProviderDependency() {
-    return ProviderBaseDependencyImpl();
+  ProviderDependency<StateController<T>> createProviderDependency() {
+    return ProviderDependencyImpl(state);
   }
 
   @override

--- a/packages/riverpod/lib/src/stream_provider/stream_provider.dart
+++ b/packages/riverpod/lib/src/stream_provider/stream_provider.dart
@@ -7,15 +7,17 @@ import '../provider/provider.dart';
 part 'auto_dispose_stream_provider.dart';
 
 /// The state of a [StreamProvider].
-class StreamProviderDependency<T> extends ProviderDependencyBase {
-  StreamProviderDependency._(this.stream, this._state);
+class StreamProviderDependency<T> extends ProviderDependencyImpl<Stream<T>> {
+  StreamProviderDependency._(this.stream, this._state) : super(stream);
+
+  @Deprecated('`stream` will be removed in 0.3.0. Use `value` instead.')
 
   /// The stream returned by [StreamProvider].
   final Stream<T> stream;
   final _State<T, ProviderBase<StreamProviderDependency<T>, AsyncValue<T>>>
       _state;
 
-  /// The last value emitted by [stream].
+  /// The last value emitted by [value].
   ///
   /// The future will fail if the last event is an error instead.ƒ
   Future<T> get currentData => _state.currentData;
@@ -89,7 +91,7 @@ class StreamProvider<T> extends AlwaysAliveProviderBase<
   /// Once an [AsyncValue.data]/[AsyncValue.error] was emitted, it is no longer
   /// possible to emit a [AsyncValue.loading].
   ///
-  /// This will create a made up [Stream] for [StreamProviderDependency.stream].
+  /// This will create a made up [Stream] for [ProviderDependency.value].
   ProviderOverride debugOverrideWithValue(AsyncValue<T> value) {
     ProviderOverride res;
     assert(() {

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and being testable.
-version: 0.1.0
+version: 0.2.0
 homepage: https://riverpod.dev
 authors:
   - Remi Rousselet <darky12s@gmail.com>

--- a/packages/riverpod/test/auto_dispose_test.dart
+++ b/packages/riverpod/test/auto_dispose_test.dart
@@ -92,7 +92,7 @@ void main() {
     final bDispose = OnDisposeMock();
     final b = AutoDisposeProvider((ref) {
       ref.onDispose(bDispose);
-      ref.read(a);
+      ref.dependOn(a);
       return '42';
     });
     final root = ProviderStateOwner();
@@ -135,7 +135,7 @@ void main() {
     final bDispose = OnDisposeMock();
     final b = AutoDisposeProvider((ref) {
       ref.onDispose(bDispose);
-      ref.read(a);
+      ref.dependOn(a);
       return '42';
     });
 
@@ -169,7 +169,7 @@ void main() {
     final onDispose2 = OnDisposeMock();
     final provider2 = AutoDisposeProvider((ref) {
       ref.onDispose(onDispose2);
-      return ref.read(provider).value;
+      return ref.dependOn(provider).value;
     });
     final listener = Listener();
 
@@ -392,13 +392,13 @@ void main() {
       ref.onDispose(onDispose);
       return value;
     });
-    final dependent = Provider((ref) => ref.read(provider).value);
+    final dependent = Provider((ref) => ref.dependOn(provider).value);
     final root = ProviderStateOwner();
     final owner = ProviderStateOwner(parent: root, overrides: [dependent]);
     final owner2 = ProviderStateOwner(parent: root, overrides: [dependent]);
 
     expect(unrelated.readOwner(owner), 42);
-    expect(owner.ref.read(dependent).value, 42);
+    expect(owner.ref.dependOn(dependent).value, 42);
 
     expect(
       root.debugProviderStates,
@@ -420,7 +420,7 @@ void main() {
     expect(root.debugProviderStates, [isA<ProviderState<int>>()]);
 
     value = 21;
-    expect(owner2.ref.read(dependent).value, 21);
+    expect(owner2.ref.dependOn(dependent).value, 21);
     verifyNoMoreInteractions(onDispose);
     expect(
       root.debugProviderStates,

--- a/packages/riverpod/test/computed_test.dart
+++ b/packages/riverpod/test/computed_test.dart
@@ -177,7 +177,7 @@ void main() {
     final owner = ProviderStateOwner();
     final provider = Provider((_) => 42);
     final computed = Computed((read) => read(provider) * 2);
-    final provider2 = Provider((ref) => ref.read(computed));
+    final provider2 = Provider((ref) => ref.dependOn(computed));
     final listener = Listener<int>();
 
     provider2.readOwner(owner);

--- a/packages/riverpod/test/framework_test.dart
+++ b/packages/riverpod/test/framework_test.dart
@@ -20,7 +20,7 @@ void main() {
   test('hasListeners', () {
     final root = ProviderStateOwner();
     final provider = Provider((_) => 42);
-    final provider2 = Provider((ref) => ref.read(provider).value * 2);
+    final provider2 = Provider((ref) => ref.dependOn(provider).value * 2);
     final owner = ProviderStateOwner(parent: root, overrides: [provider2]);
 
     expect(provider.readOwner(owner), 42);
@@ -86,7 +86,7 @@ void main() {
       'throw if tried to dispose a parent owner that still have undisposed children owners',
       () {
     final provider = Provider((_) => 42);
-    final provider2 = Provider((ref) => ref.read(provider).value * 2);
+    final provider2 = Provider((ref) => ref.dependOn(provider).value * 2);
     final root = ProviderStateOwner();
     final owner = ProviderStateOwner(parent: root, overrides: [provider2]);
 
@@ -295,7 +295,7 @@ void main() {
   });
   test('remove dependency when owner is disposed', () {
     final provider = Provider((_) {});
-    final provider2 = Provider((ref) => ref.read(provider));
+    final provider2 = Provider((ref) => ref.dependOn(provider));
     final root = ProviderStateOwner();
     final owner = ProviderStateOwner(
       parent: root,
@@ -350,8 +350,8 @@ void main() {
       ]),
     );
 
-    ref3.read(provider2);
-    ref4.read(provider2);
+    ref3.dependOn(provider2);
+    ref4.dependOn(provider2);
 
     expect(
       root.debugProviderStates,
@@ -368,7 +368,7 @@ void main() {
       ]),
     );
 
-    ref2.read(provider);
+    ref2.dependOn(provider);
 
     expect(root.debugProviderStates, <Object>[
       isProvider(provider),
@@ -406,7 +406,7 @@ void main() {
       ]),
     );
 
-    ref4.read(provider3);
+    ref4.dependOn(provider3);
 
     expect(
       owner.debugProviderStates,
@@ -416,7 +416,7 @@ void main() {
       ]),
     );
 
-    ref3.read(provider2);
+    ref3.dependOn(provider2);
 
     expect(
       owner.debugProviderStates,
@@ -427,7 +427,7 @@ void main() {
       ]),
     );
 
-    ref2.read(provider);
+    ref2.dependOn(provider);
 
     expect(owner.debugProviderStates, <Object>[
       isProvider(provider),
@@ -456,7 +456,7 @@ void main() {
     final provider2 = Provider((ref) => 0);
     final provider = Provider((ref) {
       ref.onDispose(() {
-        ref.read(provider2);
+        ref.dependOn(provider2);
       });
       return ref;
     });
@@ -504,15 +504,15 @@ void main() {
   test('Circular dependency check accross multiple owners', () {
     final provider = Provider((_) => 1);
     final provider2 = Provider((_) => 2);
-    final provider3 = Provider((ref) => ref.read(provider2).value * 2);
+    final provider3 = Provider((ref) => ref.dependOn(provider2).value * 2);
 
     final root = ProviderStateOwner(overrides: [
       provider.overrideAs(
-        Provider((ref) => ref.read(provider3).value * 2),
+        Provider((ref) => ref.dependOn(provider3).value * 2),
       )
     ]);
     final owner = ProviderStateOwner(parent: root, overrides: [
-      provider2.overrideAs(Provider((ref) => ref.read(provider).value * 2)),
+      provider2.overrideAs(Provider((ref) => ref.dependOn(provider).value * 2)),
       provider3,
     ]);
 
@@ -526,7 +526,7 @@ void main() {
       () {
     final provider1 = Provider((_) => 1);
     final provider3 = Provider((_) => '1');
-    final provider2 = Provider((ref) => ref.read(provider1).value * 2.5);
+    final provider2 = Provider((ref) => ref.dependOn(provider1).value * 2.5);
 
     final root = ProviderStateOwner();
     final owner = ProviderStateOwner(parent: root, overrides: [
@@ -612,8 +612,8 @@ void main() {
     expect(owner.ref, ref);
     expect(owner2.ref, ref2);
 
-    expect(ref.read(provider).value, 42);
-    expect(ref2.read(provider).value, 21);
+    expect(ref.dependOn(provider).value, 42);
+    expect(ref2.dependOn(provider).value, 21);
 
     owner.updateOverrides([]);
     owner2.updateOverrides([
@@ -624,8 +624,8 @@ void main() {
 
     expect(owner.ref, ref);
     expect(owner2.ref, ref2);
-    expect(ref.read(provider).value, 42);
-    expect(ref2.read(provider).value, 21);
+    expect(ref.dependOn(provider).value, 42);
+    expect(ref2.dependOn(provider).value, 21);
   });
 
   test('ref.read disposes the provider state', () {
@@ -636,7 +636,7 @@ void main() {
       });
       return 0;
     });
-    final other = Provider((ref) => ref.read(provider));
+    final other = Provider((ref) => ref.dependOn(provider));
 
     final owner = ProviderStateOwner();
     final owner2 = ProviderStateOwner(
@@ -657,10 +657,10 @@ void main() {
     final provider2 = TestProvider((ref) => 1);
     final owner = ProviderStateOwner();
 
-    final value1 = owner.ref.read(provider);
-    final value2 = owner.ref.read(provider);
-    final value21 = owner.ref.read(provider2);
-    final value22 = owner.ref.read(provider2);
+    final value1 = owner.ref.dependOn(provider);
+    final value2 = owner.ref.dependOn(provider);
+    final value21 = owner.ref.dependOn(provider2);
+    final value22 = owner.ref.dependOn(provider2);
 
     expect(value1, value2);
     expect(value1.value, 0);
@@ -692,13 +692,13 @@ void main() {
     Provider<int Function()> provider;
 
     final provider1 = Provider((ref) {
-      return ref.read(provider).value() + 1;
+      return ref.dependOn(provider).value() + 1;
     });
     final provider2 = Provider((ref) {
-      return ref.read(provider1).value + 1;
+      return ref.dependOn(provider1).value + 1;
     });
     provider = Provider((ref) {
-      return () => ref.read(provider2).value + 1;
+      return () => ref.dependOn(provider2).value + 1;
     });
 
     final owner = ProviderStateOwner();
@@ -714,12 +714,12 @@ void main() {
     final provider1 = Provider((ref) => ref);
     final provider2 = Provider((ref) => ref);
 
-    provider1.readOwner(owner).read(provider);
-    provider2.readOwner(owner).read(provider1);
+    provider1.readOwner(owner).dependOn(provider);
+    provider2.readOwner(owner).dependOn(provider1);
     final ref = provider.readOwner(owner);
 
     expect(
-      () => ref.read(provider2),
+      () => ref.dependOn(provider2),
       throwsA(isA<CircularDependencyError>()),
     );
   });
@@ -735,13 +735,13 @@ void main() {
     });
 
     final provider2 = Provider((ref) {
-      final value = ref.read(provider1).value;
+      final value = ref.dependOn(provider1).value;
       ref.onDispose(onDispose2);
       return value + 1;
     });
 
     final provider3 = Provider((ref) {
-      final value = ref.read(provider2).value;
+      final value = ref.dependOn(provider2).value;
       ref.onDispose(onDispose3);
       return value + 1;
     });
@@ -773,12 +773,12 @@ void main() {
 
     final provider2 = Provider((ref) {
       ref.onDispose(onDispose2);
-      return () => ref.read(provider1).value + 1;
+      return () => ref.dependOn(provider1).value + 1;
     });
 
     final provider3 = Provider((ref) {
       ref.onDispose(onDispose3);
-      return () => ref.read(provider2).value() + 1;
+      return () => ref.dependOn(provider2).value() + 1;
     });
 
     expect(provider3.readOwner(owner)(), 3);
@@ -797,10 +797,10 @@ void main() {
   test('update providers in dependency order', () {
     final provider = TestProvider((_) => 1);
     final provider1 = TestProvider((ref) {
-      return () => ref.read(provider).value + 1;
+      return () => ref.dependOn(provider).value + 1;
     });
     final provider2 = TestProvider((ref) {
-      return () => ref.read(provider1).value() + 1;
+      return () => ref.dependOn(provider1).value() + 1;
     });
 
     final owner = ProviderStateOwner(overrides: [
@@ -838,8 +838,8 @@ void main() {
     ProviderDependency<int> other2;
 
     final provider1 = Provider((ref) {
-      other = ref.read(provider);
-      other2 = ref.read(provider);
+      other = ref.dependOn(provider);
+      other2 = ref.dependOn(provider);
       return other.value;
     });
 
@@ -862,7 +862,7 @@ void main() {
 
     expect(ref.mounted, isFalse);
     expect(() => ref.onDispose(() {}), throwsStateError);
-    expect(() => ref.read(other), throwsStateError);
+    expect(() => ref.dependOn(other), throwsStateError);
   });
 
   test('if a provider threw on creation, subsequent reads throws too', () {
@@ -879,9 +879,9 @@ void main() {
     expect(() => provider.readOwner(owner), throwsA(error));
     expect(callCount, 1);
 
-    expect(() => owner.ref.read(provider), throwsA(error));
+    expect(() => owner.ref.dependOn(provider), throwsA(error));
     expect(callCount, 1);
-    expect(() => owner.ref.read(provider), throwsA(error));
+    expect(() => owner.ref.dependOn(provider), throwsA(error));
     expect(callCount, 1);
 
     expect(() => provider.watchOwner(owner, (value) {}), throwsA(error));
@@ -1113,11 +1113,11 @@ void main() {
 
       final provider = StateNotifierProvider<Counter>((_) => counter);
       final provider2 = StateNotifierProvider<Counter>((ref) {
-        ref.read(provider);
+        ref.dependOn(provider);
         return counter2;
       });
       final provider3 = StateNotifierProvider<Counter>((ref) {
-        ref.read(provider2);
+        ref.dependOn(provider2);
         return counter3;
       });
 

--- a/packages/riverpod/test/framework_test.dart
+++ b/packages/riverpod/test/framework_test.dart
@@ -17,6 +17,14 @@ Matcher isProvider(ProviderBase provider) {
 
 void main() {
   // TODO flushing inside mayHaveChanged calls onChanged only after all mayHaveChanged were executed
+  test('ref.read(provider) for providers with an immutable value', () {
+    final ProviderBase<ProviderDependency<int>, int> provider = Provider((_) {
+      return 42;
+    });
+    final owner = ProviderStateOwner();
+
+    expect(owner.ref.read(provider), 42);
+  });
   test('hasListeners', () {
     final root = ProviderStateOwner();
     final provider = Provider((_) => 42);

--- a/packages/riverpod/test/owner_observer_test.dart
+++ b/packages/riverpod/test/owner_observer_test.dart
@@ -227,7 +227,7 @@ void main() {
     when(observer2.didDisposeProvider(any)).thenThrow('error2');
     final observer3 = ObserverMock();
     final provider = Provider((_) => 0);
-    final provider2 = Provider((ref) => ref.read(provider).value);
+    final provider2 = Provider((ref) => ref.dependOn(provider).value);
     final onDispose = OnDisposeMock();
     final owner = ProviderStateOwner(
       overrides: [

--- a/packages/riverpod/test/provider/future_provider_test.dart
+++ b/packages/riverpod/test/provider/future_provider_test.dart
@@ -7,6 +7,18 @@ import 'package:riverpod/src/framework/framework.dart'
 import 'package:test/test.dart';
 
 void main() {
+  test('FutureProviderDependency can be assigned to ProviderDependency',
+      () async {
+    final provider = FutureProvider((ref) {
+      return Future.value(42);
+    });
+    final owner = ProviderStateOwner();
+
+    // ignore: omit_local_variable_types
+    final ProviderDependency<Future<int>> dep = owner.ref.dependOn(provider);
+
+    await expectLater(dep.value, completion(42));
+  });
   test('AutoDisposeFutureProvider', () async {
     var future = Future.value(42);
     final onDispose = OnDisposeMock();
@@ -162,9 +174,9 @@ void main() {
     final simple = Provider((_) => 21);
 
     final example = FutureProvider((ref) async {
-      final otherValue = await ref.read(other).future;
+      final otherValue = await ref.dependOn(other).value;
 
-      return '${ref.read(simple).value} $otherValue';
+      return '${ref.dependOn(simple).value} $otherValue';
     });
 
     final listener = StringListenerMock();
@@ -244,8 +256,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, completion(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, completion(42));
 
       provider.watchOwner(owner, listener);
 
@@ -270,8 +282,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, completion(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, completion(42));
 
       provider.watchOwner(owner, listener);
 
@@ -296,8 +308,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, completion(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, completion(42));
 
       provider.watchOwner(owner, listener);
 
@@ -334,8 +346,8 @@ void main() {
       verify(listener(const AsyncValue.data(42))).called(1);
       verifyNoMoreInteractions(listener);
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, completion(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, completion(42));
     });
     test('loading immediatly then error', () async {
       final provider = FutureProvider((_) async => 0);
@@ -358,8 +370,8 @@ void main() {
       verify(listener(AsyncValue.error(42, stackTrace))).called(1);
       verifyNoMoreInteractions(listener);
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, throwsA(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, throwsA(42));
     });
     test('loading immediatly then loading', () async {
       final provider = FutureProvider((_) async => 0);
@@ -386,8 +398,8 @@ void main() {
       verify(listener(const AsyncValue.data(42))).called(1);
       verifyNoMoreInteractions(listener);
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, completion(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, completion(42));
     });
     test('error immediatly then different error', () async {
       final stackTrace = StackTrace.current;
@@ -397,8 +409,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, throwsA(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, throwsA(42));
 
       provider.watchOwner(owner, listener);
 
@@ -424,8 +436,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, throwsA(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, throwsA(42));
 
       provider.watchOwner(owner, listener);
 
@@ -452,8 +464,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, throwsA(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, throwsA(42));
 
       provider.watchOwner(owner, listener);
 
@@ -479,8 +491,8 @@ void main() {
       ]);
       final listener = ListenerMock();
 
-      final dep = owner.ref.read(provider);
-      await expectLater(dep.future, throwsA(42));
+      final dep = owner.ref.dependOn(provider);
+      await expectLater(dep.value, throwsA(42));
 
       provider.watchOwner(owner, listener);
 

--- a/packages/riverpod/test/provider/provider_test.dart
+++ b/packages/riverpod/test/provider/provider_test.dart
@@ -79,7 +79,7 @@ void main() {
       final owner = ProviderStateOwner();
 
       final provider = Provider((ref) {
-        final first = ref.read(dependency);
+        final first = ref.dependOn(dependency);
         return first.value * 2;
       });
 
@@ -91,8 +91,8 @@ void main() {
       final owner = ProviderStateOwner();
 
       final provider = Provider((ref) {
-        final first = ref.read(dependency);
-        final second = ref.read(dependency2);
+        final first = ref.dependOn(dependency);
+        final second = ref.dependOn(dependency2);
 
         return '${first.value} ${second.value}';
       });

--- a/packages/riverpod/test/provider/state_notifier_provider_test.dart
+++ b/packages/riverpod/test/provider/state_notifier_provider_test.dart
@@ -4,6 +4,19 @@ import 'package:state_notifier/state_notifier.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('StateNotifierProviderDependency can be assigned to ProviderDependency',
+      () async {
+    final provider = StateNotifierProvider((ref) {
+      return StateController(0);
+    });
+    final owner = ProviderStateOwner();
+
+    // ignore: omit_local_variable_types
+    final ProviderDependency<StateController<int>> dep =
+        owner.ref.dependOn(provider);
+
+    await expectLater(dep.value.state, 0);
+  });
   test('StateNotifierFamily override', () {
     final notifier = TestNotifier();
     final notifier2 = TestNotifier(42);

--- a/packages/riverpod/test/provider/state_provider_test.dart
+++ b/packages/riverpod/test/provider/state_provider_test.dart
@@ -3,6 +3,17 @@ import 'package:riverpod/riverpod.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('StateNotifierProviderDependency can be assigned to ProviderDependency',
+      () async {
+    final provider = StateProvider((ref) => 0);
+    final owner = ProviderStateOwner();
+
+    // ignore: omit_local_variable_types
+    final ProviderDependency<StateController<int>> dep =
+        owner.ref.dependOn(provider);
+
+    await expectLater(dep.value.state, 0);
+  });
   test('StateProvideyFamily', () async {
     final provider = StateProviderFamily<String, int>((ref, a) {
       return '$a';

--- a/packages/riverpod/test/uni_directional_test.dart
+++ b/packages/riverpod/test/uni_directional_test.dart
@@ -29,7 +29,7 @@ void main() {
     final nested = Provider((_) => 0);
     final owner = ProviderStateOwner();
     final provider2 = Provider((ref) {
-      ref.read(nested);
+      ref.dependOn(nested);
       counter.increment();
       return 0;
     });

--- a/packages/riverpod/test/visit_states_test.dart
+++ b/packages/riverpod/test/visit_states_test.dart
@@ -12,11 +12,11 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
     final c = Provider<C>((ref) {
-      ref.read(b);
+      ref.dependOn(b);
       return C();
     });
 
@@ -38,16 +38,16 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
     final c = Provider<C>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return C();
     });
 
     final d = Provider<D>((ref) {
-      ref..read(b)..read(c);
+      ref..dependOn(b)..dependOn(c);
       return D();
     });
 
@@ -86,30 +86,30 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
 
     final e = Provider<E>((ref) {
-      ref.read(b);
+      ref.dependOn(b);
       return E();
     });
     final d = Provider<D>((ref) {
-      ref..read(b)..read(e);
+      ref..dependOn(b)..dependOn(e);
       return D();
     });
 
     final c = Provider<C>((ref) {
-      ref..read(a)..read(b);
+      ref..dependOn(a)..dependOn(b);
       return C();
     });
 
     final f = Provider<F>((ref) {
-      ref..read(c)..read(e);
+      ref..dependOn(c)..dependOn(e);
       return F();
     });
     final g = Provider<G>((ref) {
-      ref..read(c)..read(f);
+      ref..dependOn(c)..dependOn(f);
       return G();
     });
 
@@ -144,16 +144,16 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
     final c = Provider<C>((ref) {
-      ref..read(a)..read(b);
+      ref..dependOn(a)..dependOn(b);
       return C();
     });
 
     final d = Provider<D>((ref) {
-      ref..read(b)..read(c);
+      ref..dependOn(b)..dependOn(c);
       return D();
     });
 
@@ -180,16 +180,16 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
     final c = Provider<C>((ref) {
-      ref.read(b);
+      ref.dependOn(b);
       return C();
     });
 
     final d = Provider<D>((ref) {
-      ref..read(b)..read(c);
+      ref..dependOn(b)..dependOn(c);
       return D();
     });
 
@@ -216,21 +216,21 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
     final c = Provider<C>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return C();
     });
 
     final d = Provider<D>((ref) {
-      ref.read(b);
+      ref.dependOn(b);
       return D();
     });
 
     final e = Provider<E>((ref) {
-      ref..read(d)..read(c);
+      ref..dependOn(d)..dependOn(c);
       return E();
     });
 
@@ -261,21 +261,21 @@ void main() {
     final a = Provider<A>((ref) => A());
 
     final b = Provider<B>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return B();
     });
     final c = Provider<C>((ref) {
-      ref.read(a);
+      ref.dependOn(a);
       return C();
     });
 
     final d = Provider<D>((ref) {
-      ref.read(b);
+      ref.dependOn(b);
       return D();
     });
 
     final e = Provider<E>((ref) {
-      ref..read(d)..read(c);
+      ref..dependOn(d)..dependOn(c);
       return E();
     });
 

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -24,7 +24,7 @@ dependency_overrides:
   flutter_riverpod:
     path: ../../packages/flutter_riverpod
   riverpod:
-    path: ../../packages/riverpod" >> $BASEDIR/../packages/hooks_riverpod/pubspec.yaml
+    path: ../../packages/riverpod" >> pubspec.yaml
 
 echo "Installing hooks_riverpod"
 flutter pub get

--- a/website/docs/cookbooks/cancel_fetch_user.mdx
+++ b/website/docs/cookbooks/cancel_fetch_user.mdx
@@ -53,7 +53,7 @@ class UserRepository {
 final userRepositoryProvider = Provider<UserRepository>((ref) => UserRepository());
 
 final userProvider = FutureProviderFamily<User, int>((ref, userID) async {
-  final userRepository = ref.read(userRepositoryProvider).value;
+  final userRepository = ref.read(userRepositoryProvider);
   // TODO
 });
 ```
@@ -65,7 +65,7 @@ So we can combine both to perform our HTTP request:
 // ...
 
 final userProvider = FutureProviderFamily<User, int>((ref, userID) async {
-  final userRepository = ref.read(userRepositoryProvider).value;
+  final userRepository = ref.read(userRepositoryProvider);
   return userRepository.fetchUser(userID);
 });
 ```

--- a/website/docs/cookbooks/testing.mdx
+++ b/website/docs/cookbooks/testing.mdx
@@ -182,7 +182,7 @@ final repositoryProvider = Provider((ref) => Repository());
 /// [Repository] and doing nothing else.
 final todoListProvider = FutureProvider((ref) async {
   // Obtains the Repository instance
-  final repository = ref.read(repositoryProvider).value;
+  final repository = ref.read(repositoryProvider);
 
   // Fetch the todos and expose them to the UI.
   return repository.fetchTodos();
@@ -313,7 +313,7 @@ final repositoryProvider = Provider((ref) => Repository());
 /// [Repository] and doing nothing else.
 final todoListProvider = FutureProvider((ref) async {
   // Obtains the Repository instance
-  final repository = ref.read(repositoryProvider).value;
+  final repository = ref.read(repositoryProvider);
 
   // Fetch the todos and expose them to the UI.
   return repository.fetchTodos();

--- a/website/docs/fundamentals/getting_started.mdx
+++ b/website/docs/fundamentals/getting_started.mdx
@@ -61,7 +61,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: ^0.10.0
-  hooks_riverpod: ^0.1.0
+  hooks_riverpod: ^0.2.0
 ```
 
 Then run `flutter pub get`.
@@ -77,7 +77,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: ^0.1.0
+  flutter_riverpod: ^0.2.0
 ```
 
 Then run `flutter pub get`.
@@ -90,7 +90,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  riverpod: ^0.1.0
+  riverpod: ^0.2.0
 ```
 
 Then run `pub get`.

--- a/website/docs/fundamentals/providers.mdx
+++ b/website/docs/fundamentals/providers.mdx
@@ -119,7 +119,7 @@ We can now create another provider that will consume our `cityProvider`:
 final weatherProvider = FutureProvider((ref) async {
   // We use `ref.read` to read another provider, and we pass it the provider
   // that we want to consume. Here: cityProvider
-  final city = ref.read(cityProvider).value;
+  final city = ref.read(cityProvider);
 
   // We can then use the result to do something based on the value of `cityProvider`.
   return fetchWeather(city: city);
@@ -138,8 +138,8 @@ final cityProvider = Provider((ref) => 'London');
 final countryProvider = Provider((ref) => 'England');
 
 final weatherProvider = Provider((ref) {
-  final city = ref.read(cityProvider).value;
-  final country = ref.read(countryProvider).value;
+  final city = ref.read(cityProvider);
+  final country = ref.read(countryProvider);
 
   return Location(city: city, country: country);
 });
@@ -175,8 +175,8 @@ class Location {
   final ProviderReference _ref;
 
   String get label {
-    final city = _ref.read(cityProvider).value;
-    final country = _ref.read(countryProvider).value;
+    final city = _ref.read(cityProvider);
+    final country = _ref.read(countryProvider);
     return '$city ($country)';
   }
 }


### PR DESCRIPTION
Consider:

```dart
final provider = Provider((ref) => 0);
```

This changes:

```dart
final another = Provider((ref) {
  ref.read(provider).value;
});
```

into:

```dart
final another = Provider((ref) {
  ref.read(provider);
});
```


The previous behavior is exposed as `ref.dependOn(provider).value`, for `StreamProvider`/`FutureProvider`

Similarly, `ref.dependOn(streamProvider).stream` and `ref.dependOn(futureProvider).future` are renamed as `.value`, which makes them compatible with `ref.read(provider)`.

