### PR TITLE
[examples/marvel] Fix marvel example CircularProgressIndicator by wrapping with Center

### DIFF
--- a/examples/marvel/lib/main.dart
+++ b/examples/marvel/lib/main.dart
@@ -183,7 +183,7 @@ class CharacterItem extends HookWidget {
         Navigator.pushNamed(context, '/character');
       },
       child: character.when(
-        loading: () => const CircularProgressIndicator(),
+        loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, stack) => Text('Error $err'),
         data: (character) {
           return Card(


### PR DESCRIPTION
before | after
--- | ---
<img width="428" alt="Screen Shot 2020-07-04 at 7 21 22" src="https://user-images.githubusercontent.com/1255062/86499590-0a780200-bdc7-11ea-9be4-8b127e6b3f97.png"> | <img width="428" alt="Screen Shot 2020-07-04 at 7 21 36" src="https://user-images.githubusercontent.com/1255062/86499595-0fd54c80-bdc7-11ea-9e5c-8b30406b5c85.png">
