### PR TITLE
[examples/marvel] Enable to back from marvel detail view

### DIFF
--- a/examples/marvel/lib/main.dart
+++ b/examples/marvel/lib/main.dart
@@ -251,7 +251,9 @@ class CharacterView extends HookWidget {
 
     final character = useProvider(characterAtIndex(index));
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(
+        title: Text(character.data.value.name),
+      ),
       body: LoadingImage(url: character.data.value.thumbnail.url),
     );
   }

--- a/examples/marvel/lib/main.dart
+++ b/examples/marvel/lib/main.dart
@@ -249,12 +249,12 @@ class CharacterView extends HookWidget {
       'CharacterItem cannot be used but _characterIndex is undefined',
     );
 
-    final character = useProvider(characterAtIndex(index));
+    final character = useProvider(characterAtIndex(index)).data.value;
     return Scaffold(
       appBar: AppBar(
-        title: Text(character.data.value.name),
+        title: Text(character.name),
       ),
-      body: LoadingImage(url: character.data.value.thumbnail.url),
+      body: LoadingImage(url: character.thumbnail.url),
     );
   }
 }

--- a/examples/marvel/lib/main.dart
+++ b/examples/marvel/lib/main.dart
@@ -221,6 +221,8 @@ class LoadingImage extends StatelessWidget {
     return Image.network(
       url,
       fit: BoxFit.cover,
+      width: double.infinity,
+      height: double.infinity,
       errorBuilder: (c, err, stack) {
         return const Center(child: Text('error'));
       },
@@ -248,6 +250,9 @@ class CharacterView extends HookWidget {
     );
 
     final character = useProvider(characterAtIndex(index));
-    return LoadingImage(url: character.data.value.thumbnail.url);
+    return Scaffold(
+      appBar: AppBar(),
+      body: LoadingImage(url: character.data.value.thumbnail.url),
+    );
   }
 }


### PR DESCRIPTION
Before this change, there was no way to back from the detail view of marvel example on the device which doesn't have a physical back button.

before | after
--- | ---
<img width="545" alt="Screen Shot 2020-07-04 at 7 46 27" src="https://user-images.githubusercontent.com/1255062/86500244-c424a200-bdca-11ea-9950-c7734e5a9b00.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/1255062/86500330-44e39e00-bdcb-11ea-9cc6-d329087df010.png">


