### PR TITLE
Add link to Android Studio plugin.

### DIFF
--- a/website/docs/fundamentals/getting_started.mdx
+++ b/website/docs/fundamentals/getting_started.mdx
@@ -239,6 +239,8 @@ This will print "Hello world" in the console.
 
 If you are using `Flutter` and `Vscode` consider [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robertbrunhage.flutter-riverpod-snippets)
 
+If you are using `Flutter` and `Android Studio` consider [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
+
 ![img](/img/snippets/greetingProvider.gif)
 ![img](/img/snippets/providerFamily.gif)
 

--- a/website/docs/fundamentals/getting_started.mdx
+++ b/website/docs/fundamentals/getting_started.mdx
@@ -239,7 +239,7 @@ This will print "Hello world" in the console.
 
 If you are using `Flutter` and `Vscode` consider [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robertbrunhage.flutter-riverpod-snippets)
 
-If you are using `Flutter` and `Android Studio` consider [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
+If you are using `Flutter` and `Android Studio` or `IntelliJ` consider [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
 
 ![img](/img/snippets/greetingProvider.gif)
 ![img](/img/snippets/providerFamily.gif)


### PR DESCRIPTION
Add links to the Android studio plugin, it adds live templates similar to snippets for riverpod.
The usage is similar to the **Robert Brunhage** extension so I think I can use the illustration of **Robert Brunhage** for both.