### PR TITLE
Fix Computed and Family links on both index and Reading a provider pages

### DIFF
--- a/website/docs/fundamentals/concepts/reading.mdx
+++ b/website/docs/fundamentals/concepts/reading.mdx
@@ -374,7 +374,7 @@ class Home extends StatelessWidget {
 </TabItem>
 </Tabs>
 
-[computed]: /docs/fundamentals/computed
+[computed]: /docs/fundamentals/concepts/computed
 [stateprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateProvider-class.html
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [consumer]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Consumer-class.html

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -157,12 +157,12 @@ function Home() {
                     <br></br>
                     With
                     <code>
-                      <a href={useBaseUrl("docs/fundamentals/computed")}>
+                      <a href={useBaseUrl("docs/fundamentals/concepts/computed")}>
                         Computed
                       </a>
                     </code>
                     and
-                    <a href={useBaseUrl("docs/fundamentals/family")}>
+                    <a href={useBaseUrl("docs/fundamentals/concepts/family")}>
                       "families"
                     </a>
                     , sort your lists or do HTTP requests only when you{" "}


### PR DESCRIPTION
As a result of b397cf0, the links to both __Computed__ and __Family__ lead to a _four-oh-four_ currently - from both the landing page and the __Reading a provider__ documentation entry. This PR aims to fix the paths so they point to the indented documents.