### PR TITLE
Add Time Tracking example app for website

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -77,6 +77,12 @@ module.exports = {
           href:
             "https://github.com/lohanidamodar/flutter_firebase_starter/tree/feature/riverpod",
         },
+        {
+          type: "link",
+          label: "Time Tracking App (with Firebase)",
+          href:
+            "https://github.com/bizz84/starter_architecture_flutter_firebase",
+        },
       ],
     },
     {


### PR DESCRIPTION
Add new example from my starter architecture app:

- [https://github.com/bizz84/starter_architecture_flutter_firebase](https://github.com/bizz84/starter_architecture_flutter_firebase)