### PR TITLE
Added Blood Pressure Tracker App in Examples section

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -94,6 +94,11 @@ module.exports = {
           label: "Resocoder's Weather Bloc to Weather Riverpod",
           href: "https://github.com/campanagerald/flutter-bloc-library-v1-tutorial",
         },
+        {
+          type: "link",
+          label: "Blood Pressure Tracker App",
+          href: "https://github.com/UrosTodosijevic/blood_pressure_tracker",
+        },
       ],
     },
     {


### PR DESCRIPTION
Hi @rrousselGit, I've added my simple Blood Pressure Tracking app to the "Third party examples" section of the Riverpod site. 

App uses riverpod as state management solution, it has local database to store entries and option to export history in .csv file. UI is pretty simple so it may be interesting example for someone starting with riverpod.