### PR TITLE
Fixed one code block in docs

### DIFF
--- a/website/docs/concepts/combining_providers.mdx
+++ b/website/docs/concepts/combining_providers.mdx
@@ -79,9 +79,10 @@ An easy way to implement such scenario would be to:
 
   ```dart
   final filteredTodoListProvider = Provider<List<Todo>>((ref) {
+    final filter = ref.watch(filterProvider);
     final todos = ref.watch(todoListProvider.state);
 
-    switch (ref.watch(filterProvider)) {
+    switch (filter.state) {
       case Filter.none:
         return todos;
       case Filter.completed:


### PR DESCRIPTION
On **Combining providers** page of the docs site, the following line: 

```dart 
switch (ref.watch(filterProvider)) {
``` 

which belongs to `filteredTodoListProvider` code block would give an error: 

`Type 'StateController<Filter>' of the switch expression isn't assignable to the type 'Filter' of case expressions.`

so, I changed that code block to:
```dart
  final filteredTodoListProvider = Provider<List<Todo>>((ref) {
    final filter = ref.watch(filterProvider);
    final todos = ref.watch(todoListProvider.state);

    switch (filter.state) {
      case Filter.none:
        return todos;
      case Filter.completed:
        return todos.where((todo) => todo.completed).toList();
      case Filter.uncompleted:
        return todos.where((todo) => !todo.completed).toList();
    }
  });
  ```

Simply adding `.state` after `ref.watch(filterProvider)` in `switch` would solve the problem, but I chose the fix that was in accordance with the official **Todo list** example.