### PR TITLE
fixed the docs of provider

### DIFF
--- a/website/docs/concepts/providers.mdx
+++ b/website/docs/concepts/providers.mdx
@@ -85,12 +85,12 @@ The fact that both providers create a `String` does not cause any problem.
 :::
 
 :::caution
-For providers to work, you must add [ProviderScope] at the root of your
+For providers to work, you must add [Provider] at the root of your
 Flutter applications:
 
 ```dart
 void main() {
-  runApp(ProviderScope(child: MyApp()));
+  runApp(Provider(create: (_) => Counter(), child: MyApp()));
 }
 ```
 


### PR DESCRIPTION
There was `ProviderScope` but for provider, we need `Provider`
https://riverpod.dev/docs/concepts/providers#creating-a-provider