### PR TITLE
Add Equatable example

### DIFF
--- a/packages/flutter_riverpod/lib/src/builders.dart
+++ b/packages/flutter_riverpod/lib/src/builders.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-
 import 'internals.dart';
 
 /// Builds a [ChangeNotifierProvider].
@@ -217,68 +216,66 @@ class ChangeNotifierProviderBuilder {
   /// - Objects generated with Freezed/built_value
   /// - Objects based on `package:equatable`
   ///
-  /// Here's an example using Freezed:
+  /// This includes:
+  /// - A tuple (using `package:tuple`)
+  /// - Objects generated with Freezed/built_value, such as:
+  ///   ```dart
+  ///   @freezed
+  ///   abstract class MyParameter with _$MyParameter {
+  ///     factory MyParameter({
+  ///       int userId,
+  ///       Locale locale,
+  ///     }) = _MyParameter;
+  ///   }
   ///
-  /// ```dart
-  /// @freezed
-  /// abstract class MyParameter with _$MyParameter {
-  ///   factory MyParameter({
-  ///     int userId,
-  ///     Locale locale,
-  ///   }) = _MyParameter;
-  /// }
-  ///
-  /// final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
-  ///   print(myParameter.userId);
-  ///   print(myParameter.locale);
-  ///   // Do something with userId/locale
-  /// });
-  ///
-  /// @override
-  /// Widget build(BuildContext context, ScopedReader watch) {
-  ///   int userId; // Read the user ID from somewhere
-  ///   final locale = Localizations.localeOf(context);
-  ///
-  ///   final something = watch(
-  ///     exampleProvider(MyParameter(userId: userId, locale: locale)),
-  ///   );
-  ///
-  ///   ...
-  /// }
-  /// ```
-  ///
-  /// ```dart
-  /// class MyParameter extends Equatable  {
-  ///   factory MyParameter({
-  ///     int userId,
-  ///     Locale locale,
+  ///   final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  ///     print(myParameter.userId);
+  ///     print(myParameter.locale);
+  ///     // Do something with userId/locale
   ///   });
   ///
-  ///   int userId;
-  ///   Local local;
+  ///   @override
+  ///   Widget build(BuildContext context, ScopedReader watch) {
+  ///     int userId; // Read the user ID from somewhere
+  ///     final locale = Localizations.localeOf(context);
+  ///
+  ///     final something = watch(
+  ///       exampleProvider(MyParameter(userId: userId, locale: locale)),
+  ///     );
+  ///   }
+  ///   ```
+  ///
+  /// - Objects based on `package:equatable`, such as:
+  ///   ```dart
+  ///   class MyParameter extends Equatable  {
+  ///     factory MyParameter({
+  ///       int userId,
+  ///       Locale locale,
+  ///     });
+  ///
+  ///     int userId;
+  ///     Local local;
+  ///
+  ///     @override
+  ///     List<Object> get props => [userId,local];
+  ///   }
+  ///
+  ///   final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  ///     print(myParameter.userId);
+  ///     print(myParameter.locale);
+  ///     // Do something with userId/locale
+  ///   });
   ///
   ///   @override
-  ///   List<Object> get props => [userId,local];
-  /// }
+  ///   Widget build(BuildContext context, ScopedReader watch) {
+  ///     int userId; // Read the user ID from somewhere
+  ///     final locale = Localizations.localeOf(context);
   ///
-  /// final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
-  ///   print(myParameter.userId);
-  ///   print(myParameter.locale);
-  ///   // Do something with userId/locale
-  /// });
-  ///
-  /// @override
-  /// Widget build(BuildContext context, ScopedReader watch) {
-  ///   int userId; // Read the user ID from somewhere
-  ///   final locale = Localizations.localeOf(context);
-  ///
-  ///   final something = watch(
-  ///     exampleProvider(MyParameter(userId: userId, locale: locale)),
-  ///   );
-  ///
-  ///   ...
-  /// }
-  /// ```
+  ///     final something = watch(
+  ///       exampleProvider(MyParameter(userId: userId, locale: locale)),
+  ///     );
+  ///   }
+  ///   ```
   /// {@endtemplate}
   ChangeNotifierProviderFamilyBuilder get family {
     return const ChangeNotifierProviderFamilyBuilder();

--- a/packages/flutter_riverpod/lib/src/builders.dart
+++ b/packages/flutter_riverpod/lib/src/builders.dart
@@ -232,7 +232,40 @@ class ChangeNotifierProviderBuilder {
   ///   print(myParameter.userId);
   ///   print(myParameter.locale);
   ///   // Do something with userId/locale
-  /// })
+  /// });
+  ///
+  /// @override
+  /// Widget build(BuildContext context, ScopedReader watch) {
+  ///   int userId; // Read the user ID from somewhere
+  ///   final locale = Localizations.localeOf(context);
+  ///
+  ///   final something = watch(
+  ///     exampleProvider(MyParameter(userId: userId, locale: locale)),
+  ///   );
+  ///
+  ///   ...
+  /// }
+  /// ```
+  ///
+  /// ```dart
+  /// class MyParameter extends Equatable  {
+  ///   factory MyParameter({
+  ///     int userId,
+  ///     Locale locale,
+  ///   });
+  ///
+  ///   int userId;
+  ///   Local local;
+  ///
+  ///   @override
+  ///   List<Object> get props => [userId,local];
+  /// }
+  ///
+  /// final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  ///   print(myParameter.userId);
+  ///   print(myParameter.locale);
+  ///   // Do something with userId/locale
+  /// });
   ///
   /// @override
   /// Widget build(BuildContext context, ScopedReader watch) {

--- a/packages/riverpod/lib/src/builders.dart
+++ b/packages/riverpod/lib/src/builders.dart
@@ -1,5 +1,3 @@
-import 'package:collection/collection.dart' as c;
-
 import 'package:state_notifier/state_notifier.dart';
 
 import 'internals.dart';
@@ -219,35 +217,66 @@ class StateProviderBuilder {
   /// - Objects generated with Freezed/built_value
   /// - Objects based on `package:equatable`
   ///
-  /// Here's an example using Freezed:
+  /// This includes:
+  /// - A tuple (using `package:tuple`)
+  /// - Objects generated with Freezed/built_value, such as:
+  ///   ```dart
+  ///   @freezed
+  ///   abstract class MyParameter with _$MyParameter {
+  ///     factory MyParameter({
+  ///       int userId,
+  ///       Locale locale,
+  ///     }) = _MyParameter;
+  ///   }
   ///
-  /// ```dart
-  /// @freezed
-  /// abstract class MyParameter with _$MyParameter {
-  ///   factory MyParameter({
-  ///     int userId,
-  ///     Locale locale,
-  ///   }) = _MyParameter;
-  /// }
+  ///   final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  ///     print(myParameter.userId);
+  ///     print(myParameter.locale);
+  ///     // Do something with userId/locale
+  ///   });
   ///
-  /// final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
-  ///   print(myParameter.userId);
-  ///   print(myParameter.locale);
-  ///   // Do something with userId/locale
-  /// })
+  ///   @override
+  ///   Widget build(BuildContext context, ScopedReader watch) {
+  ///     int userId; // Read the user ID from somewhere
+  ///     final locale = Localizations.localeOf(context);
   ///
-  /// @override
-  /// Widget build(BuildContext context, ScopedReader watch) {
-  ///   int userId; // Read the user ID from somewhere
-  ///   final locale = Localizations.localeOf(context);
+  ///     final something = watch(
+  ///       exampleProvider(MyParameter(userId: userId, locale: locale)),
+  ///     );
+  ///   }
+  ///   ```
   ///
-  ///   final something = watch(
-  ///     exampleProvider(MyParameter(userId: userId, locale: locale)),
-  ///   );
+  /// - Objects based on `package:equatable`, such as:
+  ///   ```dart
+  ///   class MyParameter extends Equatable  {
+  ///     factory MyParameter({
+  ///       int userId,
+  ///       Locale locale,
+  ///     });
   ///
-  ///   ...
-  /// }
-  /// ```
+  ///     int userId;
+  ///     Local local;
+  ///
+  ///     @override
+  ///     List<Object> get props => [userId,local];
+  ///   }
+  ///
+  ///   final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  ///     print(myParameter.userId);
+  ///     print(myParameter.locale);
+  ///     // Do something with userId/locale
+  ///   });
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context, ScopedReader watch) {
+  ///     int userId; // Read the user ID from somewhere
+  ///     final locale = Localizations.localeOf(context);
+  ///
+  ///     final something = watch(
+  ///       exampleProvider(MyParameter(userId: userId, locale: locale)),
+  ///     );
+  ///   }
+  ///   ```
   /// {@endtemplate}
   StateProviderFamilyBuilder get family {
     return const StateProviderFamilyBuilder();

--- a/tools/generate_providers/bin/generate_providers.dart
+++ b/tools/generate_providers/bin/generate_providers.dart
@@ -254,35 +254,66 @@ const _familyDoc = r'''
 /// - Objects generated with Freezed/built_value
 /// - Objects based on `package:equatable`
 ///
-/// Here's an example using Freezed:
+/// This includes:
+/// - A tuple (using `package:tuple`)
+/// - Objects generated with Freezed/built_value, such as:
+///   ```dart
+///   @freezed
+///   abstract class MyParameter with _$MyParameter {
+///     factory MyParameter({
+///       int userId,
+///       Locale locale,
+///     }) = _MyParameter;
+///   }
 ///
-/// ```dart
-/// @freezed
-/// abstract class MyParameter with _$MyParameter {
-///   factory MyParameter({
-///     int userId,
-///     Locale locale,
-///   }) = _MyParameter;
-/// }
+///   final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+///     print(myParameter.userId);
+///     print(myParameter.locale);
+///     // Do something with userId/locale
+///   });
 ///
-/// final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
-///   print(myParameter.userId);
-///   print(myParameter.locale);
-///   // Do something with userId/locale
-/// })
+///   @override
+///   Widget build(BuildContext context, ScopedReader watch) {
+///     int userId; // Read the user ID from somewhere
+///     final locale = Localizations.localeOf(context);
 ///
-/// @override
-/// Widget build(BuildContext context, ScopedReader watch) {
-///   int userId; // Read the user ID from somewhere
-///   final locale = Localizations.localeOf(context);
+///     final something = watch(
+///       exampleProvider(MyParameter(userId: userId, locale: locale)),
+///     );
+///   }
+///   ```
 ///
-///   final something = watch(
-///     exampleProvider(MyParameter(userId: userId, locale: locale)),
-///   );
+/// - Objects based on `package:equatable`, such as:
+///   ```dart
+///   class MyParameter extends Equatable  {
+///     factory MyParameter({
+///       int userId,
+///       Locale locale,
+///     });
 ///
-///   ...
-/// }
-/// ```
+///     int userId;
+///     Local local;
+///
+///     @override
+///     List<Object> get props => [userId,local];
+///   }
+///
+///   final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+///     print(myParameter.userId);
+///     print(myParameter.locale);
+///     // Do something with userId/locale
+///   });
+///
+///   @override
+///   Widget build(BuildContext context, ScopedReader watch) {
+///     int userId; // Read the user ID from somewhere
+///     final locale = Localizations.localeOf(context);
+///
+///     final something = watch(
+///       exampleProvider(MyParameter(userId: userId, locale: locale)),
+///     );
+///   }
+///   ```
 /// {@endtemplate}''';
 
 bool _didAddFamilyTemplate = false;

--- a/website/docs/concepts/modifiers/family.mdx
+++ b/website/docs/concepts/modifiers/family.mdx
@@ -103,6 +103,17 @@ This includes:
 
 Here's an example using [Freezed]:
 
+<Tabs
+  groupId="family"
+  defaultValue="Freezed"
+  values={[
+    { label: 'Freezed', value: 'freezed', },
+    { label: 'Equatable', value: 'equatable', },
+  ]}
+>
+
+<TabItem value="freezed">
+
 ```dart
 @freezed
 abstract class MyParameter with _$MyParameter {
@@ -116,7 +127,7 @@ final exampleProvider = Provider.autoDispose.family<Something, MyParameter>((ref
   print(myParameter.userId);
   print(myParameter.locale);
   // Do something with userId/locale
-})
+});
 
 @override
 Widget build(BuildContext context, ScopedReader watch) {
@@ -130,6 +141,43 @@ Widget build(BuildContext context, ScopedReader watch) {
   ...
 }
 ```
+
+</TabItem>
+<TabItem value="equatable">
+
+```dart
+class MyParameter extends Equatable  {
+  factory MyParameter({
+    int userId,
+    Locale locale,
+  });
+
+  int userId;
+  Local local;
+
+  @override
+  List<Object> get props => [userId,local];
+}
+
+final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  print(myParameter.userId);
+  print(myParameter.locale);
+  // Do something with userId/locale
+});
+
+@override
+Widget build(BuildContext context, ScopedReader watch) {
+  int userId; // Read the user ID from somewhere
+  final locale = Localizations.localeOf(context);
+
+  final something = watch(
+    exampleProvider(MyParameter(userId: userId, locale: locale)),
+  );
+
+  ...
+}
+```
+</TabItem>
 
 [freezed]: https://pub.dev/packages/freezed
 [provider]: https://pub.dev/documentation/riverpod/latest/all/Provider-class.html

--- a/website/docs/concepts/modifiers/family.mdx
+++ b/website/docs/concepts/modifiers/family.mdx
@@ -101,11 +101,11 @@ This includes:
 - Objects generated with [Freezed] or [built_value](https://pub.dev/packages/built_value)
 - Objects using [equatable](https://pub.dev/packages/equatable)
 
-Here's an example using [Freezed]:
+Here's an example using [Freezed] and [equatable]:
 
 <Tabs
   groupId="family"
-  defaultValue="Freezed"
+  defaultValue="freezed"
   values={[
     { label: 'Freezed', value: 'freezed', },
     { label: 'Equatable', value: 'equatable', },
@@ -178,6 +178,7 @@ Widget build(BuildContext context, ScopedReader watch) {
 }
 ```
 </TabItem>
+</Tabs>
 
 [freezed]: https://pub.dev/packages/freezed
 [provider]: https://pub.dev/documentation/riverpod/latest/all/Provider-class.html

--- a/website/docs/concepts/modifiers/family.mdx
+++ b/website/docs/concepts/modifiers/family.mdx
@@ -182,4 +182,5 @@ Widget build(BuildContext context, ScopedReader watch) {
 
 [freezed]: https://pub.dev/packages/freezed
 [provider]: https://pub.dev/documentation/riverpod/latest/all/Provider-class.html
+[equatable]: https://pub.dev/packages/equatable
 [futureprovider]: https://pub.dev/documentation/riverpod/latest/all/FutureProvider-class.html


### PR DESCRIPTION
Have added Equatable example in .family (https://riverpod.dev/docs/concepts/modifiers/family#passing-multiple-parameters-to-a-family).

Thanks