### PR TITLE
#263: Export AutoDisposeProviderReference

### DIFF
--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -21,6 +21,7 @@ export 'src/framework.dart'
         RootProvider,
         ProviderBase,
         Override,
+        AutoDisposeProviderReference,
         ProviderReference,
         ProviderListenable,
         ProviderContainer,


### PR DESCRIPTION
Exposing `AutoDisposeProviderReference` so we can use the library in strongly-typed mode.