### PR TITLE
context.read can now receive ScopedProviders as parameter

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -3,6 +3,7 @@
 - deprecated `import 'flutter_riverpod/all.dart'`. Now everything is available with `flutter_riverpod/flutter_riverpod.dart`.
 - removed the assert preventing ConsumerWidget's "watch" from being used after the `build` method completed.
   This allows "watch" to be used inside `ListView.builder`.
+- `context.read(myProvider)` now accepts `ScopeProviders`
 
 # 0.13.0-nullsafety.2
 

--- a/packages/flutter_riverpod/lib/src/provider.dart
+++ b/packages/flutter_riverpod/lib/src/provider.dart
@@ -73,7 +73,7 @@ extension BuildContextX on BuildContext {
   /// While more verbose than [read], using [Provider]/`select` is a lot safer.
   /// It does not rely on implementation details on `Model`, and it makes
   /// impossible to have a bug where our UI does not refresh.
-  T read<T>(RootProvider<Object, T> provider) {
+  T read<T>(ProviderBase<Object, T> provider) {
     return ProviderScope.containerOf(this, listen: false).read(provider);
   }
 

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -3,6 +3,7 @@
 - deprecated `import 'hooks_riverpod/all.dart'`. Now everything is available with `hooks_riverpod/hooks_riverpod.dart`.
 - removed the assert preventing ConsumerWidget's "watch" from being used after the `build` method completed.
   This allows "watch" to be used inside `ListView.builder`.
+- `context.read(myProvider)` now accepts `ScopeProviders`
 
 # 0.13.0-nullsafety.2
 


### PR DESCRIPTION
closes https://github.com/rrousselGit/river_pod/issues/274