### PR TITLE
improve check non-root ProviderContainer/ProviderScope condition

### DIFF
--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -61,9 +61,8 @@ class ProviderContainer {
         );
       }
       for (final override in overrides) {
-        if (override is ProviderOverride &&
-            override._origin is ScopedProvider) {
-        } else {
+        if (override is! ProviderOverride ||
+            override._origin is! ScopedProvider) {
           throw UnsupportedError(
             'Cannot override providers on a non-root ProviderContainer/ProviderScope',
           );


### PR DESCRIPTION
will stop as soon as either side fails, instead of always checking both sides.