### PR TITLE
Listen to a provider ref.listen<T>(provider, onChange)

### DIFF
--- a/packages/riverpod/lib/src/framework/base_provider.dart
+++ b/packages/riverpod/lib/src/framework/base_provider.dart
@@ -430,6 +430,30 @@ abstract class ProviderReference {
   ///   sorted only once.
   /// - if nothing is listening to `sortedTodosProvider`, then no sort if performed.
   T watch<T>(AlwaysAliveProviderBase<Object?, T> provider);
+
+  /// This will allow a provider to listen to state changes of another provider by
+  /// providing an [onChange] callback.
+  /// [onChange] will not be called during the build of the provider.
+  ///
+  /// It will _not_ rebuild the listening provider.
+  ///
+  /// [onChange] will no longer be called after the listening provider has been
+  /// disposed.
+  ///
+  /// It is not recommended to [watch] **and** [listenTo] to the same provider.
+  ///
+  /// ```dart
+  /// final setDataProvider = StateProvider<Data>((ref) => Data());
+  /// final myStateNotifierProvider = StateNotifierProvider<MyNotifier>((ref) {
+  ///   final myNotifier = MyNotifier();
+  ///   ref.listenTo<StateController<Data>>(setDataProvider, (ctrl) {
+  ///     myNotifier.recomputeStateWith(ctrl.state);
+  ///   });
+  ///   return myNotifier;
+  /// });
+  /// ```
+  void listenTo<T>(AlwaysAliveProviderBase<Object?, T> provider,
+      void Function(T state) onChange);
 }
 
 class _Listener<Listened> extends LinkedListEntry<_Listener<Listened>> {
@@ -616,6 +640,26 @@ class ProviderElement<Created, Listened> implements ProviderReference {
       _dependencyMayHaveChanged = true;
       notifyMayHaveChanged();
     }
+  }
+
+  @override
+  void listenTo<T>(
+    ProviderBase<Object?, T> provider,
+    void Function(T state) onChange,
+  ) {
+    assert(_debugAssertCanDependOn(provider), '');
+
+    final sub = _container.listen<T>(
+      provider,
+      mayHaveChanged: (subscription) {
+        Future.microtask(() {
+          if (subscription.flush()) {
+            onChange(subscription.read());
+          }
+        });
+      },
+    );
+    onDispose(sub.close);
   }
 
   /// Listen to this provider.

--- a/packages/riverpod/test/ref_listen_test.dart
+++ b/packages/riverpod/test/ref_listen_test.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('can listen to other provider', () async {
+    final listen = ListenIntMock();
+    final container = ProviderContainer();
+    final event = StateProvider((_) => 1);
+    final provider = Provider((ref) {
+      ref.listenTo<StateController<int>>(event, (ctrl) {
+        listen(ctrl.state);
+      });
+
+      return 0;
+    });
+
+    container.read(provider);
+    verifyZeroInteractions(listen);
+
+    container.read(event).state++;
+    container.read(provider);
+
+    await Future<void>.value();
+
+    container.read(event).state++;
+    container.read(provider);
+
+    await Future<void>.value();
+
+    verify(listen(2)).called(1);
+    verify(listen(3)).called(1);
+  });
+
+  test('family can listen', () async {
+    final listen = ListenIntMock();
+    final container = ProviderContainer();
+    final event = StateProvider((_) => 1);
+    final provider = Provider.family<int, int>((ref, i) {
+      ref.listenTo<StateController<int>>(event, (ctrl) {
+        listen(ctrl.state);
+      });
+
+      return i;
+    });
+
+    container.read(provider(0));
+    container.read(provider(1));
+    verifyZeroInteractions(listen);
+
+    container.read(event).state++;
+    container.read(provider(0));
+    container.read(provider(1));
+
+    await Future<void>.value();
+
+    container.read(event).state++;
+    container.read(provider(0));
+    container.read(provider(1));
+
+    await Future<void>.value();
+
+    verifyInOrder([listen(2), listen(2), listen(3), listen(3)]);
+  });
+
+  test('listenTo does not rebuild provider', () async {
+    final build1 = CallCountMock();
+    final build2 = CallCountMock();
+    final listen = CallCountMock();
+    final container = ProviderContainer();
+    final event = StateProvider((_) => 0);
+    final provider1 = StateNotifierProvider<StateController<int>>((ref) {
+      build1();
+      final stateNotifier = StateController(0);
+      ref.listenTo<StateController<int>>(event, (ctrl) {
+        stateNotifier.state = ctrl.state;
+      });
+      return stateNotifier;
+    });
+    final provider2 = Provider((ref) {
+      build2();
+      ref.listenTo<int>(provider1.state, (ctrl) {
+        listen();
+      });
+      return 0;
+    });
+
+    container.read(provider2);
+
+    container.read(event).state++;
+
+    await Future<void>.value();
+    await Future<void>.value();
+    verify(listen()).called(1);
+
+    container.read(event).state++;
+
+    await Future<void>.value();
+    await Future<void>.value();
+    verify(listen()).called(1);
+
+    verify(build1()).called(1);
+    verify(build2()).called(1);
+  });
+
+  test('rebuild of listened will trigger listener', () async {
+    final container = ProviderContainer();
+    var i = 0;
+    final event = Provider((_) => i);
+    final provider = Provider((ref) {
+      ref.listenTo(event, (state) {
+        i++;
+      });
+      return -1;
+    });
+
+    container.read(provider);
+    container.refresh(event);
+
+    await Future<void>.value();
+    expect(i, 1);
+  });
+
+  test('remove listener on dispose', () async {
+    final container = ProviderContainer();
+    final event = StateProvider((_) => 1);
+    final provider = Provider.autoDispose((ref) {
+      ref.listenTo<StateController<int>>(event, (ctrl) {});
+
+      return 0;
+    });
+
+    final sub = container.listen(provider);
+
+    expect(container.readProviderElement(event).hasListeners, isTrue);
+    sub.close();
+    await Future<void>.value();
+    expect(container.readProviderElement(event).hasListeners, isFalse);
+  });
+}
+
+class ListenIntMock extends Mock {
+  void call(int i);
+}
+
+class CallCountMock extends Mock {
+  void call();
+}


### PR DESCRIPTION
Hello! There have been some requests already for the proposed feature in the RFC about listening to a provider with a ref.
#339 #385 #186

Since this is not a breaking change, I figured it would be better to split the `listen` feature from @smiLLe in  #302 into a separate PR/release of riverpod.
This is just the `listen` part, without the `setState` functionality that was talked about.

Regarding the implementation, it works the same as the `ProviderListener`, even the microtask, although that is something that I'm  not sure if it has to be done with a microtask for the case of a `ref.listen`.
Another thought is the naming of the function. If we want to name it just `listen` it would be good to rename the private `listen` function in the `ProviderElement` to avoid confusion with the public API.

I don't know what is your current progress with the RFC or what is your final decision about it, so feel free to close this if you don't think it fits to release this functionality at the moment.