### PR TITLE
Hide the `Listener`/`LocatorMixin` typedefs

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [Unreleased major]
+
+- **BREAKING-CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
+  could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+
 # 0.13.1+1
 
 Fixed an issue where `context.read` and `ProviderListener` were unable to read providers that return a nullable value

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [Unreleased major]
+
+- **BREAKING-CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
+  could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+
 # 0.13.1+1
 
 Fixed an issue where `context.read` and `ProviderListener` were unable to read providers that return a nullable value

--- a/packages/hooks_riverpod/test/version_test.dart
+++ b/packages/hooks_riverpod/test/version_test.dart
@@ -2,6 +2,13 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+extension on String {
+  String escapeRegexp() {
+    return replaceAllMapped(
+        RegExp(r'[\.\+]'), (match) => '\\${match.group(0)}');
+  }
+}
+
 void main() {
   final packageOffsetInPath =
       Directory.current.path.lastIndexOf('/hooks_riverpod');
@@ -22,19 +29,19 @@ void main() {
       return RegExp(
         r'\bversion:\s*([0-9]+\.[0-9]+\.[0-9]+.*)$',
         multiLine: true,
-      ).firstMatch(pub)!.group(1);
+      ).firstMatch(pub)!.group(1)!.escapeRegexp();
     });
     final hooksVersion = await hooksPubspec.readAsString().then((pub) {
       return RegExp(
         r'\bversion:\s*([0-9]+\.[0-9]+\.[0-9]+.*)$',
         multiLine: true,
-      ).firstMatch(pub)!.group(1);
+      ).firstMatch(pub)!.group(1)!.escapeRegexp();
     });
     final flutterVersion = await flutterPubspec.readAsString().then((pub) {
       return RegExp(
         r'\bversion:\s*([0-9]+\.[0-9]+\.[0-9]+.*)$',
         multiLine: true,
-      ).firstMatch(pub)!.group(1);
+      ).firstMatch(pub)!.group(1)!.escapeRegexp();
     });
 
     expect(

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [Unreleased major]
+
+- Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
+  could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+
 # 0.13.1
 
 - Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/river_pod/issues/355)

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased major]
 
-- Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
+- **BREAKING-CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
   could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
 
 # 0.13.1

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -1,4 +1,4 @@
-export 'package:state_notifier/state_notifier.dart';
+export 'package:state_notifier/state_notifier.dart' hide Listener, LocatorMixin;
 
 export 'src/common.dart'
     show


### PR DESCRIPTION
The former could cause a name conflict with the widget named
`Listener` and the latter is not supported when using Riverpod.

fixes #384