### PR TITLE
Implements RFC 341

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Long story short:
   class Example extends ConsumerWidget {
     @override
     Widget build(BuildContext context, ScopedReader watch) {
-      final count = watch(counterProvider.state);
+      final count = watch(counterProvider);
       return Text(count.toString());
     }
   }
@@ -69,10 +69,10 @@ See the [FAQ](#FAQ) if you have questions about what this means for [provider].
 - [Motivation](#motivation)
 - [Contributing](#contributing)
 - [FAQ](#faq)
-  - [Why another project when provider already exists?](#why-another-project-when-provider-already-exists)
+  - [Why another project when [provider] already exists?](#why-another-project-when-provider-already-exists)
   - [Is it safe to use in production?](#is-it-safe-to-use-in-production)
-  - [Will this get merged with provider at some point?](#will-this-get-merged-with-provider-at-some-point)
-  - [Will provider be deprecated/stop being supported?](#will-provider-be-deprecatedstop-being-supported)
+  - [Will this get merged with [provider] at some point?](#will-this-get-merged-with-provider-at-some-point)
+  - [Will [provider] be deprecated/stop being supported?](#will-provider-be-deprecatedstop-being-supported)
 
 ## Motivation
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,9 +12,6 @@ analyzer:
     # in this file
     included_file_warning: ignore
 
-    # Causes false positives (https://github.com/dart-lang/sdk/issues/41571
-    top_level_function_literal_block: ignore
-
 linter:
   rules:
     # Personal preference. I don't find it more readable

--- a/examples/marvel/lib/src/configuration.dart
+++ b/examples/marvel/lib/src/configuration.dart
@@ -16,14 +16,14 @@ abstract class Configuration with _$Configuration {
     required String privateKey,
   }) = _Configuration;
 
-  factory Configuration.fromJson(Map<String, dynamic> json) =>
+  factory Configuration.fromJson(Map<String, Object?> json) =>
       _$ConfigurationFromJson(json);
 }
 
-final configurationsProvider = FutureProvider((_) async {
+final configurationsProvider = FutureProvider<Configuration>((_) async {
   final content = json.decode(
     await rootBundle.loadString('assets/configurations.json'),
-  ) as Map<String, dynamic>;
+  ) as Map<String, Object?>;
 
   return Configuration.fromJson(content);
 });

--- a/examples/marvel/lib/src/fake_marvel.dart
+++ b/examples/marvel/lib/src/fake_marvel.dart
@@ -27,7 +27,7 @@ class FakeDio implements Dio {
   @override
   Future<Response<T>> get<T>(
     String path, {
-    required Map<String, dynamic> queryParameters,
+    required Map<String, Object?> queryParameters,
     Options? options,
     CancelToken? cancelToken,
     ProgressCallback? onReceiveProgress,
@@ -65,11 +65,11 @@ class FakeDio implements Dio {
   }
 }
 
-class FakeResponse implements Response<Map<String, dynamic>> {
+class FakeResponse implements Response<Map<String, Object?>> {
   FakeResponse(this.data);
 
   @override
-  final Map<String, dynamic> data;
+  final Map<String, Object?> data;
 
   @override
   void noSuchMethod(Invocation invocation) {

--- a/examples/marvel/lib/src/marvel.dart
+++ b/examples/marvel/lib/src/marvel.dart
@@ -122,7 +122,7 @@ abstract class Character with _$Character {
     required Thumbnail thumbnail,
   }) = _Character;
 
-  factory Character.fromJson(Map<String, dynamic> json) =>
+  factory Character.fromJson(Map<String, Object?> json) =>
       _$CharacterFromJson(json);
 }
 
@@ -134,7 +134,7 @@ abstract class Thumbnail with _$Thumbnail {
   }) = _Thumbnail;
   Thumbnail._();
 
-  factory Thumbnail.fromJson(Map<String, dynamic> json) =>
+  factory Thumbnail.fromJson(Map<String, Object?> json) =>
       _$ThumbnailFromJson(json);
 
   late final String url =
@@ -145,17 +145,17 @@ abstract class Thumbnail with _$Thumbnail {
 abstract class MarvelResponse with _$MarvelResponse {
   factory MarvelResponse(MarvelData data) = _MarvelResponse;
 
-  factory MarvelResponse.fromJson(Map<String, dynamic> json) =>
+  factory MarvelResponse.fromJson(Map<String, Object?> json) =>
       _$MarvelResponseFromJson(json);
 }
 
 @freezed
 abstract class MarvelData with _$MarvelData {
   factory MarvelData(
-    List<Map<String, dynamic>> results,
+    List<Map<String, Object?>> results,
     int total,
   ) = _MarvelData;
 
-  factory MarvelData.fromJson(Map<String, dynamic> json) =>
+  factory MarvelData.fromJson(Map<String, Object?> json) =>
       _$MarvelDataFromJson(json);
 }

--- a/examples/todos/lib/main.dart
+++ b/examples/todos/lib/main.dart
@@ -116,7 +116,7 @@ class Home extends HookWidget {
               Dismissible(
                 key: ValueKey(todos[i].id),
                 onDismissed: (_) {
-                  context.read(todoListProvider).remove(todos[i]);
+                  context.read(todoListProvider.notifier).remove(todos[i]);
                 },
                 child: ProviderScope(
                   overrides: [

--- a/examples/todos/lib/main.dart
+++ b/examples/todos/lib/main.dart
@@ -15,7 +15,7 @@ final allFilterKey = UniqueKey();
 ///
 /// We are using [StateNotifierProvider] here as a `List<Todo>` is a complex
 /// object, with advanced business logic like how to edit a todo.
-final todoListProvider = StateNotifierProvider((ref) {
+final todoListProvider = StateNotifierProvider<TodoList, List<Todo>>((ref) {
   return TodoList([
     Todo(id: 'todo-0', description: 'hi'),
     Todo(id: 'todo-1', description: 'hello'),
@@ -44,20 +44,17 @@ final todoListFilter = StateProvider((_) => TodoListFilter.all);
 ///
 /// This will also optimise unneeded rebuilds if the todo-list changes, but the
 /// number of uncompleted todos doesn't (such as when editing a todo).
-final uncompletedTodosCount = Provider((ref) {
-  return ref
-      .watch(todoListProvider.state)
-      .where((todo) => !todo.completed)
-      .length;
+final uncompletedTodosCount = Provider<int>((ref) {
+  return ref.watch(todoListProvider).where((todo) => !todo.completed).length;
 });
 
 /// The list of todos after applying of [todoListFilter].
 ///
 /// This too uses [Provider], to avoid recomputing the filtered list unless either
 /// the filter of or the todo-list updates.
-final filteredTodos = Provider((ref) {
+final filteredTodos = Provider<List<Todo>>((ref) {
   final filter = ref.watch(todoListFilter);
-  final todos = ref.watch(todoListProvider.state);
+  final todos = ref.watch(todoListProvider);
 
   switch (filter.state) {
     case TodoListFilter.completed:
@@ -107,7 +104,7 @@ class Home extends HookWidget {
                 labelText: 'What needs to be done?',
               ),
               onSubmitted: (value) {
-                context.read(todoListProvider).add(value);
+                context.read(todoListProvider.notifier).add(value);
                 newTodoController.clear();
               },
             ),
@@ -250,7 +247,7 @@ class TodoItem extends HookWidget {
           } else {
             // Commit changes only when the textfield is unfocused, for performance
             context
-                .read(todoListProvider)
+                .read(todoListProvider.notifier)
                 .edit(id: todo.id, description: textEditingController.text);
           }
         },
@@ -262,7 +259,7 @@ class TodoItem extends HookWidget {
           leading: Checkbox(
             value: todo.completed,
             onChanged: (value) =>
-                context.read(todoListProvider).toggle(todo.id),
+                context.read(todoListProvider.notifier).toggle(todo.id),
           ),
           title: isFocused
               ? TextField(

--- a/examples/todos/test/widget_test.dart
+++ b/examples/todos/test/widget_test.dart
@@ -148,7 +148,7 @@ void main() {
     expect(firstItem, findsOneWidget);
 
     // dismiss the item
-    await tester.drag(firstItem, const Offset(500, 0));
+    await tester.drag(firstItem, const Offset(1000, 0));
 
     // wait for animation to finish
     await tester.pumpAndSettle();

--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,7 +1,46 @@
 # [Unreleased major]
 
-- **BREAKING-CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
-  could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+- **BREAKING CHANGE** The `Listener`/`LocatorMixin` typedefs are removed as the former could cause a name
+  conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+- **BREAKING CHANGE** The syntax for using `StateNotifierProvider` was updated.
+  Before:
+
+  ```dart
+  class MyStateNotifier extends StateNotifier<MyModel> {...}
+
+  final provider = StateNotifierProvider<MyStateNotifier>((ref) => MyStateNotifier());
+
+  ...
+  Widget build(context, watch) {
+    MyStateNotifier notifier = watch(provider);
+    MyModel model = watch(provider.state);
+  }
+  ```
+
+  After:
+
+  ```dart
+  class MyStateNotifier extends StateNotifier<MyModel> {...}
+
+  final provider = StateNotifierProvider<MyStateNotifier, MyModel>>((ref) => MyStateNotifier());
+
+  ...
+  Widget build(context, watch) {
+    MyStateNotifier notifier = watch(provider.notifier);
+    MyModel model = watch(provider);
+  }
+  ```
+
+  See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
+
+- **BREAKING CHANGE** It is no-longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
+- feat: Calling `ProviderContainer.dispose` multiple time no-longer throws.
+  This simplifies the tear-off logic of tests.
+- feat: Added `ChangeNotifierProvider.notifier` and `StateProvider.notifier`
+  They allow obtaining the notifier associated to the provider, without causing widgets/providers to rebuild when the state updates. 
+- fix: overriding a `StateNotifierProvider`/`ChangeNotifierProvider` with `overrideWithValue` now correctly listens to the notifier.
+
+# 0.1
 
 # 0.13.1+1
 

--- a/packages/flutter_riverpod/lib/src/builders.dart
+++ b/packages/flutter_riverpod/lib/src/builders.dart
@@ -1,3 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+//
+// If you need to modify this file, instead update /tools/generate_providers/bin/generate_providers.dart
+//
+// You can install this utility by executing:
+// dart pub global activate -s path <repository_path>/tools/generate_providers
+//
+// You can then use it in your terminal by executing:
+// generate_providers <riverpod/flutter_riverpod/hooks_riverpod> <path to builder file to update>
+
 import 'package:flutter/foundation.dart';
 import 'internals.dart';
 
@@ -56,8 +66,8 @@ class ChangeNotifierProviderBuilder {
   /// });
   /// ```
   /// {@endtemplate}
-  ChangeNotifierProvider<T> call<T extends ChangeNotifier>(
-    T Function(ProviderReference ref) create, {
+  ChangeNotifierProvider<Notifier> call<Notifier extends ChangeNotifier>(
+    Notifier Function(ProviderReference ref) create, {
     String? name,
   }) {
     return ChangeNotifierProvider(create, name: name);
@@ -288,8 +298,9 @@ class ChangeNotifierProviderFamilyBuilder {
   const ChangeNotifierProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  ChangeNotifierProviderFamily<T, Value> call<T extends ChangeNotifier, Value>(
-    T Function(ProviderReference ref, Value value) create, {
+  ChangeNotifierProviderFamily<Notifier, Param>
+      call<Notifier extends ChangeNotifier, Param>(
+    Notifier Function(ProviderReference ref, Param param) create, {
     String? name,
   }) {
     return ChangeNotifierProviderFamily(create, name: name);
@@ -307,8 +318,9 @@ class AutoDisposeChangeNotifierProviderBuilder {
   const AutoDisposeChangeNotifierProviderBuilder();
 
   /// {@macro riverpod.autoDispose}
-  AutoDisposeChangeNotifierProvider<T> call<T extends ChangeNotifier>(
-    T Function(AutoDisposeProviderReference ref) create, {
+  AutoDisposeChangeNotifierProvider<Notifier>
+      call<Notifier extends ChangeNotifier>(
+    Notifier Function(AutoDisposeProviderReference ref) create, {
     String? name,
   }) {
     return AutoDisposeChangeNotifierProvider(create, name: name);
@@ -326,9 +338,9 @@ class AutoDisposeChangeNotifierProviderFamilyBuilder {
   const AutoDisposeChangeNotifierProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  AutoDisposeChangeNotifierProviderFamily<T, Value>
-      call<T extends ChangeNotifier, Value>(
-    T Function(AutoDisposeProviderReference ref, Value value) create, {
+  AutoDisposeChangeNotifierProviderFamily<Notifier, Param>
+      call<Notifier extends ChangeNotifier, Param>(
+    Notifier Function(AutoDisposeProviderReference ref, Param param) create, {
     String? name,
   }) {
     return AutoDisposeChangeNotifierProviderFamily(create, name: name);

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider.dart
@@ -38,3 +38,29 @@ mixin _ChangeNotifierProviderStateMixin<T extends ChangeNotifier?>
     super.dispose();
   }
 }
+
+Override _overrideWithValue<T extends ChangeNotifier>(
+  ProviderBase provider,
+  T value,
+) {
+  return ProviderOverride(
+    ValueProvider<T, T>((ref) {
+      VoidCallback? removeListener;
+
+      void listen(T value) {
+        removeListener?.call();
+        // ignore: invalid_use_of_protected_member
+        value.addListener(ref.markDidChange);
+        // ignore: invalid_use_of_protected_member
+        removeListener = () => value.removeListener(ref.markDidChange);
+      }
+
+      listen(value);
+      ref.onChange = listen;
+
+      ref.onDispose(() => removeListener?.call());
+      return value;
+    }, value),
+    provider,
+  );
+}

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
@@ -3,15 +3,22 @@ part of '../change_notifier_provider.dart';
 /// {@macro riverpod.changenotifierprovider}
 @sealed
 class AutoDisposeChangeNotifierProvider<T extends ChangeNotifier>
-    extends AutoDisposeProviderBase<T, T> {
+    extends AutoDisposeProviderBase<T, T> with ProviderOverridesMixin<T, T> {
   /// {@macro riverpod.changenotifierprovider}
   AutoDisposeChangeNotifierProvider(
-    Create<T, AutoDisposeProviderReference> create, {
+    this._create, {
     String? name,
-  }) : super(create, name);
+  }) : super(name);
 
   /// {@macro riverpod.family}
   static const family = ChangeNotifierProviderFamilyBuilder();
+
+  final Create<T, AutoDisposeProviderReference> _create;
+
+  @override
+  T create(covariant AutoDisposeProviderReference ref) {
+    return _create(ref);
+  }
 
   @override
   _AutoDisposeChangeNotifierProviderState<T> createState() =>

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
@@ -14,6 +14,12 @@ class AutoDisposeChangeNotifierProvider<T extends ChangeNotifier>
   /// {@macro riverpod.family}
   static const family = ChangeNotifierProviderFamilyBuilder();
 
+  late final AutoDisposeProviderBase<T, T> notifier =
+      AutoDisposeProvider((ref) => ref.watch(this));
+
+  @override
+  Override overrideWithValue(T value) => _overrideWithValue(this, value);
+
   final Create<T, AutoDisposeProviderReference> _create;
 
   @override

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
@@ -14,6 +14,7 @@ class AutoDisposeChangeNotifierProvider<T extends ChangeNotifier>
   /// {@macro riverpod.family}
   static const family = ChangeNotifierProviderFamilyBuilder();
 
+  /// {@macro flutter_riverpod.changenotifierprovider.notifier}
   late final AutoDisposeProviderBase<T, T> notifier =
       AutoDisposeProvider((ref) => ref.watch(this));
 

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/auto_dispose.dart
@@ -3,7 +3,8 @@ part of '../change_notifier_provider.dart';
 /// {@macro riverpod.changenotifierprovider}
 @sealed
 class AutoDisposeChangeNotifierProvider<T extends ChangeNotifier>
-    extends AutoDisposeProviderBase<T, T> with ProviderOverridesMixin<T, T> {
+    extends AutoDisposeProviderBase<T, T>
+    with AutoDisposeProviderOverridesMixin<T, T> {
   /// {@macro riverpod.changenotifierprovider}
   AutoDisposeChangeNotifierProvider(
     this._create, {

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/base.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/base.dart
@@ -13,6 +13,12 @@ class ChangeNotifierProvider<T extends ChangeNotifier>
   /// {@macro riverpod.autoDispose}
   static const autoDispose = AutoDisposeChangeNotifierProviderBuilder();
 
+  late final AlwaysAliveProviderBase<T, T> notifier =
+      Provider((ref) => ref.watch(this));
+
+  @override
+  Override overrideWithValue(T value) => _overrideWithValue(this, value);
+
   final Create<T, ProviderReference> _create;
 
   @override

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/base.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/base.dart
@@ -13,6 +13,27 @@ class ChangeNotifierProvider<T extends ChangeNotifier>
   /// {@macro riverpod.autoDispose}
   static const autoDispose = AutoDisposeChangeNotifierProviderBuilder();
 
+  /// {@template flutter_riverpod.changenotifierprovider.notifier}
+  /// Obtains the [ChangeNotifier] associated with this provider, but without
+  /// listening to it.
+  ///
+  /// Listening to this provider may cause providers/widgets to rebuild in the
+  /// event that the [ChangeNotifier] it recreated.
+  ///
+  ///
+  /// It is preferrable to do:
+  /// ```dart
+  /// ref.watch(changeNotifierProvider.notifier)
+  /// ```
+  ///
+  /// instead of:
+  /// ```dart
+  /// ref.read(changeNotifierProvider)
+  /// ```
+  ///
+  /// The reasoning is, using `read` could cause hard to catch bugs, such as
+  /// not rebuilding dependent providers/widgets after using `context.refresh` on this provider.
+  /// {@endtemplate}
   late final AlwaysAliveProviderBase<T, T> notifier =
       Provider((ref) => ref.watch(this));
 

--- a/packages/flutter_riverpod/lib/src/change_notifier_provider/base.dart
+++ b/packages/flutter_riverpod/lib/src/change_notifier_provider/base.dart
@@ -3,18 +3,20 @@ part of '../change_notifier_provider.dart';
 /// {@macro riverpod.changenotifierprovider}
 @sealed
 class ChangeNotifierProvider<T extends ChangeNotifier>
-    extends AlwaysAliveProviderBase<T, T> {
+    extends AlwaysAliveProviderBase<T, T> with ProviderOverridesMixin<T, T> {
   /// {@macro riverpod.changenotifierprovider}
-  ChangeNotifierProvider(
-    Create<T, ProviderReference> create, {
-    String? name,
-  }) : super(create, name);
+  ChangeNotifierProvider(this._create, {String? name}) : super(name);
 
   /// {@macro riverpod.family}
   static const family = ChangeNotifierProviderFamilyBuilder();
 
   /// {@macro riverpod.autoDispose}
   static const autoDispose = AutoDisposeChangeNotifierProviderBuilder();
+
+  final Create<T, ProviderReference> _create;
+
+  @override
+  T create(ProviderReference ref) => _create(ref);
 
   @override
   _ChangeNotifierProviderState<T> createState() =>

--- a/packages/flutter_riverpod/test/auto_dispose_change_notifier_provider_test.dart
+++ b/packages/flutter_riverpod/test/auto_dispose_change_notifier_provider_test.dart
@@ -49,6 +49,29 @@ void main() {
     verifyNoMoreInteractions(listener2);
   });
 
+  test('.notifier does not notify listeners when notifyListeners is called',
+      () {
+    final notifier = TestNotifier();
+    final provider = ChangeNotifierProvider.autoDispose((_) => notifier);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(
+      provider.notifier,
+      didChange: (_) => callCount++,
+    );
+
+    expect(callCount, 0);
+    expect(sub.read(), notifier);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 0);
+    expect(sub.read(), notifier);
+  });
+
   test('family override', () {
     final provider = ChangeNotifierProvider.autoDispose
         .family<ValueNotifier<int>, int>((ref, value) {
@@ -114,6 +137,105 @@ void main() {
 
     expect(notifier.mounted, isFalse);
   });
+
+  test(
+      'overrideWithValue listens to the notifier, support notifier change, and does not dispose of the notifier',
+      () async {
+    final provider = ChangeNotifierProvider.autoDispose((_) => TestNotifier());
+    final notifier = TestNotifier();
+    final notifier2 = TestNotifier();
+    final container = ProviderContainer(overrides: [
+      provider.overrideWithValue(notifier),
+    ]);
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(provider, didChange: (_) => callCount++);
+    final notifierSub = container.listen(provider.notifier);
+
+    expect(sub.read(), notifier);
+    expect(callCount, 0);
+    expect(notifierSub.read(), notifier);
+    expect(notifier.hasListeners, true);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 1);
+
+    container.updateOverrides([
+      provider.overrideWithValue(notifier2),
+    ]);
+
+    sub.flush();
+    expect(callCount, 2);
+    expect(notifier.hasListeners, false);
+    expect(notifier2.hasListeners, true);
+    expect(notifier.mounted, true);
+    expect(notifierSub.read(), notifier2);
+
+    notifier2.count++;
+
+    sub.flush();
+    expect(callCount, 3);
+
+    container.dispose();
+
+    expect(callCount, 3);
+    expect(notifier2.hasListeners, false);
+    expect(notifier2.mounted, true);
+    expect(notifier.mounted, true);
+  });
+
+  test('overrideWithProvider preserves the state accross update', () {
+    final provider = ChangeNotifierProvider.autoDispose((_) {
+      return TestNotifier();
+    });
+    final notifier = TestNotifier();
+    final notifier2 = TestNotifier();
+    final container = ProviderContainer(overrides: [
+      provider.overrideWithProvider(
+        ChangeNotifierProvider.autoDispose((_) => notifier),
+      ),
+    ]);
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(provider, didChange: (_) => callCount++);
+
+    expect(sub.read(), notifier);
+    expect(container.read(provider.notifier), notifier);
+    expect(notifier.hasListeners, true);
+    expect(callCount, 0);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 1);
+
+    container.updateOverrides([
+      provider.overrideWithProvider(
+        ChangeNotifierProvider.autoDispose((_) => notifier2),
+      ),
+    ]);
+
+    sub.flush();
+    expect(callCount, 1);
+    expect(container.read(provider.notifier), notifier);
+    expect(notifier2.hasListeners, false);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 2);
+    expect(container.read(provider.notifier), notifier);
+    expect(notifier.mounted, true);
+
+    container.dispose();
+
+    expect(callCount, 2);
+    expect(notifier.mounted, false);
+  });
 }
 
 class OnDisposeMock extends Mock {
@@ -126,6 +248,10 @@ class Listener<T> extends Mock {
 
 class TestNotifier extends ChangeNotifier {
   bool mounted = true;
+
+  @override
+  // ignore: unnecessary_overrides
+  bool get hasListeners => super.hasListeners;
 
   int _count = 0;
   int get count => _count;

--- a/packages/flutter_riverpod/test/change_notifier_provider_test.dart
+++ b/packages/flutter_riverpod/test/change_notifier_provider_test.dart
@@ -78,10 +78,132 @@ void main() {
 
     expect(notifier.mounted, isFalse);
   });
+
+  test('.notifier does not notify listeners when notifyListeners is called',
+      () {
+    final notifier = TestNotifier();
+    final provider = ChangeNotifierProvider((_) => notifier);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(
+      provider.notifier,
+      didChange: (_) => callCount++,
+    );
+
+    expect(callCount, 0);
+    expect(sub.read(), notifier);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 0);
+    expect(sub.read(), notifier);
+  });
+
+  test(
+      'overrideWithValue listens to the notifier, support notifier change, and does not dispose of the notifier',
+      () async {
+    final provider = ChangeNotifierProvider((_) => TestNotifier());
+    final notifier = TestNotifier();
+    final notifier2 = TestNotifier();
+    final container = ProviderContainer(overrides: [
+      provider.overrideWithValue(notifier),
+    ]);
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(provider, didChange: (_) => callCount++);
+    final notifierSub = container.listen(provider.notifier);
+
+    expect(sub.read(), notifier);
+    expect(callCount, 0);
+    expect(notifierSub.read(), notifier);
+    expect(notifier.hasListeners, true);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 1);
+
+    container.updateOverrides([
+      provider.overrideWithValue(notifier2),
+    ]);
+
+    sub.flush();
+    expect(callCount, 2);
+    expect(notifier.hasListeners, false);
+    expect(notifier2.hasListeners, true);
+    expect(notifier.mounted, true);
+    expect(notifierSub.read(), notifier2);
+
+    notifier2.count++;
+
+    sub.flush();
+    expect(callCount, 3);
+
+    container.dispose();
+
+    expect(callCount, 3);
+    expect(notifier2.hasListeners, false);
+    expect(notifier2.mounted, true);
+    expect(notifier.mounted, true);
+  });
+
+  test('overrideWithProvider preserves the state accross update', () {
+    final provider = ChangeNotifierProvider((_) {
+      return TestNotifier();
+    });
+    final notifier = TestNotifier();
+    final notifier2 = TestNotifier();
+    final container = ProviderContainer(overrides: [
+      provider.overrideWithProvider(ChangeNotifierProvider((_) => notifier)),
+    ]);
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(provider, didChange: (_) => callCount++);
+
+    expect(sub.read(), notifier);
+    expect(container.read(provider.notifier), notifier);
+    expect(notifier.hasListeners, true);
+    expect(callCount, 0);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 1);
+
+    container.updateOverrides([
+      provider.overrideWithProvider(ChangeNotifierProvider((_) => notifier2)),
+    ]);
+
+    sub.flush();
+    expect(callCount, 1);
+    expect(container.read(provider.notifier), notifier);
+    expect(notifier2.hasListeners, false);
+
+    notifier.count++;
+
+    sub.flush();
+    expect(callCount, 2);
+    expect(container.read(provider.notifier), notifier);
+    expect(notifier.mounted, true);
+
+    container.dispose();
+
+    expect(callCount, 2);
+    expect(notifier.mounted, false);
+  });
 }
 
 class TestNotifier extends ChangeNotifier {
   bool mounted = true;
+
+  @override
+  // ignore: unnecessary_overrides
+  bool get hasListeners => super.hasListeners;
 
   int _count = 0;
   int get count => _count;

--- a/packages/flutter_riverpod/test/consumer_test.dart
+++ b/packages/flutter_riverpod/test/consumer_test.dart
@@ -75,19 +75,22 @@ void main() {
     final stateProvider = StateProvider((ref) => 0, name: 'state');
     final notifier0 = TestNotifier();
     final notifier1 = TestNotifier(42);
-    final provider0 = StateNotifierProvider((_) => notifier0, name: '0');
-    final provider1 = StateNotifierProvider((_) => notifier1, name: '1');
+    final provider0 = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier0;
+    }, name: '0');
+    final provider1 = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier1;
+    }, name: '1');
     var buildCount = 0;
 
     await tester.pumpWidget(ProviderScope(
       child: Consumer(builder: (c, watch, _) {
         buildCount++;
         final state = watch(stateProvider).state;
-        final value =
-            state == 0 ? watch(provider0.state) : watch(provider1.state);
+        final value = state == 0 ? watch(provider0) : watch(provider1);
 
         return Text(
-          '${watch(provider0.state)} $value',
+          '${watch(provider0)} $value',
           textDirection: TextDirection.ltr,
         );
       }),
@@ -96,13 +99,13 @@ void main() {
         .state<ProviderScopeState>(find.byType(ProviderScope))
         .container;
 
-    container.read(provider0.state);
-    container.read(provider1.state);
+    container.read(provider0);
+    container.read(provider1);
     final familyState0 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider0.state;
+      return p.provider == provider0;
     });
     final familyState1 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider1.state;
+      return p.provider == provider1;
     });
 
     expect(buildCount, 1);
@@ -149,8 +152,12 @@ void main() {
     final stateProvider = StateProvider((ref) => 0, name: 'state');
     final notifier0 = TestNotifier();
     final notifier1 = TestNotifier(42);
-    final provider0 = StateNotifierProvider((_) => notifier0, name: '0');
-    final provider1 = StateNotifierProvider((_) => notifier1, name: '1');
+    final provider0 = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier0;
+    }, name: '0');
+    final provider1 = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier1;
+    }, name: '1');
     var buildCount = 0;
 
     await tester.pumpWidget(
@@ -159,8 +166,8 @@ void main() {
           buildCount++;
           final state = watch(stateProvider).state;
           final result = state == 0 //
-              ? watch(provider0.state)
-              : watch(provider1.state);
+              ? watch(provider0)
+              : watch(provider1);
           return Text('$result', textDirection: TextDirection.ltr);
         }),
       ),
@@ -169,13 +176,13 @@ void main() {
         .state<ProviderScopeState>(find.byType(ProviderScope))
         .container;
 
-    container.read(provider0.state);
-    container.read(provider1.state);
+    container.read(provider0);
+    container.read(provider1);
     final familyState0 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider0.state;
+      return p.provider == provider0;
     });
     final familyState1 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider1.state;
+      return p.provider == provider1;
     });
 
     expect(buildCount, 1);
@@ -217,16 +224,20 @@ void main() {
 
   testWidgets('Consumer supports changing the provider', (tester) async {
     final notifier1 = TestNotifier();
-    final provider1 = StateNotifierProvider((_) => notifier1);
+    final provider1 = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier1;
+    });
     final notifier2 = TestNotifier(42);
-    final provider2 = StateNotifierProvider((_) => notifier2);
+    final provider2 = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier2;
+    });
     var buildCount = 0;
 
-    Widget build(StateNotifierProvider<TestNotifier> provider) {
+    Widget build(StateNotifierProvider<TestNotifier, int> provider) {
       return ProviderScope(
         child: Consumer(builder: (c, watch, _) {
           buildCount++;
-          final value = watch(provider.state);
+          final value = watch(provider);
           return Text('$value', textDirection: TextDirection.ltr);
         }),
       );
@@ -259,17 +270,19 @@ void main() {
       'mutliple watch, when one of them forces rebuild, all dependencies are still flushed',
       (tester) async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier;
+    });
     var callCount = 0;
-    final computed = Provider((ref) {
+    final computed = Provider<int>((ref) {
       callCount++;
-      return ref.watch(provider.state);
+      return ref.watch(provider);
     });
 
     await tester.pumpWidget(
       ProviderScope(
         child: Consumer(builder: (context, watch, _) {
-          final first = watch(provider.state);
+          final first = watch(provider);
           final second = watch(computed);
           return Text(
             '$first $second',
@@ -292,8 +305,8 @@ void main() {
   testWidgets("don't rebuild if Provider ref't actually change",
       (tester) async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider((_) => notifier);
-    final computed = Provider((ref) => !ref.watch(provider.state).isNegative);
+    final provider = StateNotifierProvider<TestNotifier, int>((_) => notifier);
+    final computed = Provider((ref) => !ref.watch(provider).isNegative);
     var buildCount = 0;
 
     await tester.pumpWidget(
@@ -332,16 +345,17 @@ void main() {
 
   testWidgets('remove listener when changing container', (tester) async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider((_) => notifier, name: 'provider');
+    final provider = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier;
+    }, name: 'provider');
     final notifier2 = TestNotifier(42);
-    final override = StateNotifierProvider((_) => notifier2, name: 'override');
     const firstOwnerKey = Key('first');
     const secondOwnerKey = Key('second');
     final key = GlobalKey();
 
     final consumer = Consumer(
         builder: (context, watch, _) {
-          final value = watch(provider.state);
+          final value = watch(provider);
           return Text('$value', textDirection: TextDirection.ltr);
         },
         key: key);
@@ -356,7 +370,7 @@ void main() {
           ProviderScope(
             key: secondOwnerKey,
             overrides: [
-              provider.overrideWithProvider(override),
+              provider.overrideWithValue(notifier2),
             ],
             child: Container(),
           ),
@@ -368,8 +382,8 @@ void main() {
         .firstState<ProviderScopeState>(find.byKey(firstOwnerKey))
         .container;
 
-    final state1 = owner1.debugProviderElements
-        .firstWhere((s) => s.provider == provider.state);
+    final state1 =
+        owner1.debugProviderElements.firstWhere((s) => s.provider == provider);
 
     expect(state1.hasListeners, true);
     expect(find.text('0'), findsOneWidget);
@@ -384,7 +398,7 @@ void main() {
           ProviderScope(
             key: secondOwnerKey,
             overrides: [
-              provider.overrideWithProvider(override),
+              provider.overrideWithValue(notifier2),
             ],
             child: consumer,
           ),
@@ -397,7 +411,7 @@ void main() {
         .container;
 
     final state2 = container2.debugProviderElements
-        .firstWhere((s) => s.provider is StateNotifierStateProvider);
+        .firstWhere((s) => s.provider is StateNotifierProvider);
 
     expect(find.text('0'), findsNothing);
     expect(find.text('42'), findsOneWidget);
@@ -415,12 +429,12 @@ void main() {
 
   testWidgets('remove listener when destroying the consumer', (tester) async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<TestNotifier, int>((_) => notifier);
 
     await tester.pumpWidget(
       ProviderScope(
         child: Consumer(builder: (context, watch, _) {
-          final value = watch(provider.state);
+          final value = watch(provider);
           return Text('$value', textDirection: TextDirection.ltr);
         }),
       ),
@@ -431,7 +445,7 @@ void main() {
         .container;
 
     final state = container.debugProviderElements
-        .firstWhere((s) => s.provider == provider.state);
+        .firstWhere((s) => s.provider == provider);
 
     expect(state.hasListeners, true);
     expect(find.text('0'), findsOneWidget);
@@ -447,15 +461,19 @@ void main() {
 
   testWidgets('Multiple providers', (tester) async {
     final notifier = TestNotifier();
-    final firstProvider = StateNotifierProvider((_) => notifier);
+    final firstProvider = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier;
+    });
     final notifier2 = TestNotifier();
-    final secondProvider = StateNotifierProvider((_) => notifier2);
+    final secondProvider = StateNotifierProvider<TestNotifier, int>((_) {
+      return notifier2;
+    });
 
     await tester.pumpWidget(
       ProviderScope(
         child: Consumer(builder: (context, watch, _) {
-          final first = watch(firstProvider.state);
-          final second = watch(secondProvider.state);
+          final first = watch(firstProvider);
+          final second = watch(secondProvider);
           return Text(
             'first $first second $second',
             textDirection: TextDirection.ltr,
@@ -480,12 +498,12 @@ void main() {
 
   testWidgets('Consumer', (tester) async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<TestNotifier, int>((_) => notifier);
 
     await tester.pumpWidget(
       ProviderScope(
         child: Consumer(builder: (context, watch, _) {
-          final count = watch(provider.state);
+          final count = watch(provider);
           return Text('$count', textDirection: TextDirection.ltr);
         }),
       ),

--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -564,7 +564,9 @@ class Demo extends StatefulWidget {
     required this.builder,
   }) : super(key: key);
 
+  // ignore: diagnostic_describe_all_properties
   final void Function(BuildContext context) initState;
+  // ignore: diagnostic_describe_all_properties
   final Widget Function(BuildContext context) builder;
 
   @override

--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -325,7 +325,9 @@ void main() {
 
   testWidgets('ProviderScope debugFillProperties', (tester) async {
     final unnamed = Provider((_) => 0);
-    final named = StateNotifierProvider((_) => Counter(), name: 'counter');
+    final named = StateNotifierProvider<Counter, int>((_) {
+      return Counter();
+    }, name: 'counter');
     final scopeKey = GlobalKey();
 
     await tester.pumpWidget(
@@ -333,7 +335,7 @@ void main() {
         key: scopeKey,
         child: Consumer(builder: (c, watch, _) {
           final value = watch(unnamed);
-          final count = watch(named.state);
+          final count = watch(named);
           return Text(
             'value: $value count: $count',
             textDirection: TextDirection.ltr,
@@ -352,20 +354,22 @@ void main() {
         'overrides: [], '
         'state: ProviderScopeState#00000, '
         'Provider<int>#00000: 0, '
-        "counter: Instance of 'Counter', "
-        'counter.state: 0)',
+        'counter: 0, '
+        "counter.notifier: Instance of 'Counter')",
       ),
     );
   });
 
   testWidgets('UncontrolledProviderScope debugFillProperties', (tester) async {
     final unnamed = Provider((_) => 0);
-    final named = StateNotifierProvider((_) => Counter(), name: 'counter');
+    final named = StateNotifierProvider<Counter, int>((_) {
+      return Counter();
+    }, name: 'counter');
     final container = ProviderContainer();
     final scopeKey = GlobalKey();
 
     container.read(unnamed);
-    container.read(named.state);
+    container.read(named);
 
     await tester.pumpWidget(
       UncontrolledProviderScope(
@@ -381,25 +385,25 @@ void main() {
         equalsIgnoringHashCodes(
           'UncontrolledProviderScope-[GlobalKey#00000]('
           'Provider<int>#00000: 0, '
-          "counter: Instance of 'Counter', "
-          'counter.state: 0)',
+          'counter: 0, '
+          "counter.notifier: Instance of 'Counter')",
         ),
         equalsIgnoringHashCodes(
           'UncontrolledProviderScope-[GlobalKey#00000]('
-          "counter: Instance of 'Counter', "
+          'counter: 0, '
           'Provider<int>#00000: 0, '
-          'counter.state: 0)',
+          "counter.notifier: Instance of 'Counter')",
         ),
         equalsIgnoringHashCodes(
           'UncontrolledProviderScope-[GlobalKey#00000]('
-          'counter.state: 0, '
+          "counter.notifier: Instance of 'Counter', "
           'Provider<int>#00000: 0, '
           "counter: Instance of 'Counter')",
         ),
         equalsIgnoringHashCodes(
           'UncontrolledProviderScope-[GlobalKey#00000]('
-          "counter: Instance of 'Counter', "
-          'counter.state: 0, '
+          'counter: 0, '
+          "counter.notifier: Instance of 'Counter', "
           'Provider<int>#00000: 0)',
         ),
       ]),

--- a/packages/flutter_riverpod/test/future_provider_test.dart
+++ b/packages/flutter_riverpod/test/future_provider_test.dart
@@ -43,7 +43,7 @@ void main() {
     final error = Error();
     final futureProvider = FutureProvider<int>((s) async => throw error);
 
-    dynamic whenError;
+    Object? whenError;
     StackTrace? whenStack;
 
     await tester.pumpWidget(
@@ -54,7 +54,8 @@ void main() {
             return watch(futureProvider).when(
               data: (data) => Text(data.toString()),
               loading: () => const Text('loading'),
-              error: (dynamic err, stack) {
+              // ignore: avoid_types_on_closure_parameters
+              error: (Object err, stack) {
                 whenError = err;
                 whenStack = stack;
                 return const Text('error');

--- a/packages/flutter_riverpod/test/utils.dart
+++ b/packages/flutter_riverpod/test/utils.dart
@@ -95,8 +95,8 @@ class _EqualsIgnoringHashCodes extends Matcher {
   }
 
   @override
-  bool matches(dynamic object, Map<dynamic, dynamic> matchState) {
-    final description = _normalize(object as String);
+  bool matches(Object? object, Map<Object?, Object?> matchState) {
+    final description = _normalize(object! as String);
     if (_value != description) {
       matchState[_mismatchedValueKey] = description;
       return false;
@@ -111,13 +111,13 @@ class _EqualsIgnoringHashCodes extends Matcher {
 
   @override
   Description describeMismatch(
-    dynamic item,
+    Object? item,
     Description mismatchDescription,
-    Map<dynamic, dynamic> matchState,
+    Map<Object?, Object?> matchState,
     bool verbose,
   ) {
     if (matchState.containsKey(_mismatchedValueKey)) {
-      final actualValue = matchState[_mismatchedValueKey] as String;
+      final actualValue = matchState[_mismatchedValueKey] as String?;
       // Leading whitespace is added so that lines in the multiline
       // description returned by addDescriptionOf are all indented equally
       // which makes the output easier to read for this case.

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,7 +1,44 @@
 # [Unreleased major]
 
-- **BREAKING-CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
-  could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+- **BREAKING CHANGE** The `Listener`/`LocatorMixin` typedefs are removed as the former could cause a name
+  conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+- **BREAKING CHANGE** The syntax for using `StateNotifierProvider` was updated.
+  Before:
+
+  ```dart
+  class MyStateNotifier extends StateNotifier<MyModel> {...}
+
+  final provider = StateNotifierProvider<MyStateNotifier>((ref) => MyStateNotifier());
+
+  ...
+  Widget build(context, watch) {
+    MyStateNotifier notifier = watch(provider);
+    MyModel model = watch(provider.state);
+  }
+  ```
+
+  After:
+
+  ```dart
+  class MyStateNotifier extends StateNotifier<MyModel> {...}
+
+  final provider = StateNotifierProvider<MyStateNotifier, MyModel>>((ref) => MyStateNotifier());
+
+  ...
+  Widget build(context, watch) {
+    MyStateNotifier notifier = watch(provider.notifier);
+    MyModel model = watch(provider);
+  }
+  ```
+
+  See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
+
+- **BREAKING CHANGE** It is no-longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
+- feat: Calling `ProviderContainer.dispose` multiple time no-longer throws.
+  This simplifies the tear-off logic of tests.
+- feat: Added `ChangeNotifierProvider.notifier` and `StateProvider.notifier`
+  They allow obtaining the notifier associated to the provider, without causing widgets/providers to rebuild when the state updates.
+- fix: overriding a `StateNotifierProvider`/`ChangeNotifierProvider` with `overrideWithValue` now correctly listens to the notifier.
 
 # 0.13.1+1
 

--- a/packages/hooks_riverpod/example/lib/main.dart
+++ b/packages/hooks_riverpod/example/lib/main.dart
@@ -18,7 +18,7 @@ void main() {
 /// Providers are declared as global variables.
 /// This does not hinder testability, as the state of a provider is instead
 /// stored inside a [ProviderScope].
-final counterProvider = StateNotifierProvider<Counter>((_) => Counter());
+final counterProvider = StateNotifierProvider<Counter, int>((_) => Counter());
 
 /// A simple [StateNotifier] that implements a counter.
 ///
@@ -48,7 +48,7 @@ class MyHomePage extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final count = useProvider(counterProvider.state);
+    final count = useProvider(counterProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -61,7 +61,7 @@ class MyHomePage extends HookWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => context.read(counterProvider).increment(),
+        onPressed: () => context.read(counterProvider.notifier).increment(),
         child: const Icon(Icons.add),
       ),
     );

--- a/packages/hooks_riverpod/lib/src/use_provider.dart
+++ b/packages/hooks_riverpod/lib/src/use_provider.dart
@@ -84,14 +84,14 @@ class _ProviderHookState<T> extends HookState<T, _ProviderHook<T>> {
 
     if (oldHook._container != hook._container) {
       _listen();
-    } else if (link is SelectorSubscription<dynamic, T>) {
+    } else if (link is SelectorSubscription<Object?, T>) {
       assert(
-        hook._providerListenable is ProviderSelector<dynamic, T>,
+        hook._providerListenable is ProviderSelector<Object?, T>,
         'useProvider was updated from `useProvider(provider.select(...)) '
         'to useProvider(provider), which is unsupported',
       );
-      if ((hook._providerListenable as ProviderSelector<dynamic, T>).provider !=
-          (oldHook._providerListenable as ProviderSelector<dynamic, T>)
+      if ((hook._providerListenable as ProviderSelector<Object?, T>).provider !=
+          (oldHook._providerListenable as ProviderSelector<Object?, T>)
               .provider) {
         _listen();
       } else {

--- a/packages/hooks_riverpod/test/framework_test.dart
+++ b/packages/hooks_riverpod/test/framework_test.dart
@@ -46,18 +46,18 @@ void main() {
       'mutliple useProviders, when one of them forces rebuild, all dependencies are still flushed',
       (tester) async {
     final notifier = Counter();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Counter, int>((_) => notifier);
     var callCount = 0;
     final computed = Provider((ref) {
       callCount++;
-      return ref.watch(provider.state);
+      return ref.watch(provider);
     });
 
     await tester.pumpWidget(
       ProviderScope(
         child: HookBuilder(
           builder: (context) {
-            final first = useProvider(provider.state);
+            final first = useProvider(provider);
             final second = useProvider(computed);
             return Text(
               '$first $second',

--- a/packages/hooks_riverpod/test/future_provider1_test.dart
+++ b/packages/hooks_riverpod/test/future_provider1_test.dart
@@ -19,7 +19,8 @@ void main() {
             return useProvider(futureProviderFamily).when(
               data: (value) => Text(value.toString()),
               loading: () => const Text('loading'),
-              error: (dynamic err, stack) => const Text('error'),
+              // ignore: avoid_types_on_closure_parameters
+              error: (Object? err, stack) => const Text('error'),
             );
           }),
         ),
@@ -49,7 +50,8 @@ void main() {
             return useProvider(futureProviderFamily).when(
               data: (value) => Text(value.toString()),
               loading: () => const Text('loading'),
-              error: (dynamic err, stack) => const Text('error'),
+              // ignore: avoid_types_on_closure_parameters
+              error: (Object? err, stack) => const Text('error'),
             );
           }),
         ),
@@ -78,7 +80,8 @@ void main() {
             return useProvider(futureProviderFamily).when(
               data: (value) => Text(value.toString()),
               loading: () => const Text('loading'),
-              error: (dynamic err, stack) => const Text('error'),
+              // ignore: avoid_types_on_closure_parameters
+              error: (Object? err, stack) => const Text('error'),
             );
           }),
         ),

--- a/packages/hooks_riverpod/test/future_provider_test.dart
+++ b/packages/hooks_riverpod/test/future_provider_test.dart
@@ -17,7 +17,8 @@ void main() {
             return useProvider(future).when(
               data: (data) => Text(data.toString()),
               loading: () => const Text('loading'),
-              error: (dynamic err, stack) => Text('$err'),
+              // ignore: avoid_types_on_closure_parameters
+              error: (Object? err, stack) => Text('$err'),
             );
           }),
         ),
@@ -35,7 +36,7 @@ void main() {
     final error = Error();
     final futureProvider = FutureProvider<int>((s) async => throw error);
 
-    dynamic whenError;
+    Object? whenError;
     StackTrace? whenStack;
 
     await tester.pumpWidget(
@@ -46,7 +47,8 @@ void main() {
             return useProvider(futureProvider).when(
               data: (data) => Text(data.toString()),
               loading: () => const Text('loading'),
-              error: (dynamic err, stack) {
+              // ignore: avoid_types_on_closure_parameters
+              error: (Object? err, stack) {
                 whenError = err;
                 whenStack = stack;
                 return const Text('error');
@@ -157,7 +159,8 @@ void main() {
         future = ref.watch(futureProvider.future)!
           ..then(
             (value) => completed = true,
-            onError: (dynamic _) => completed = true,
+            // ignore: avoid_types_on_closure_parameters
+            onError: (Object? _) => completed = true,
           );
         return '';
       },
@@ -176,7 +179,8 @@ void main() {
         return useProvider(futureProvider).when(
           data: (data) => Text(data.toString()),
           loading: () => const Text('loading'),
-          error: (dynamic err, stack) {
+          // ignore: avoid_types_on_closure_parameters
+          error: (Object? err, stack) {
             return const Text('error');
           },
         );

--- a/packages/hooks_riverpod/test/internal_test.dart
+++ b/packages/hooks_riverpod/test/internal_test.dart
@@ -10,17 +10,17 @@ void main() {
   testWidgets('useProvider supports changing the selected provider',
       (tester) async {
     final notifier1 = Counter();
-    final provider1 = StateNotifierProvider((_) => notifier1);
+    final provider1 = StateNotifierProvider<Counter, int>((_) => notifier1);
     final notifier2 = Counter(42);
-    final provider2 = StateNotifierProvider((_) => notifier2);
+    final provider2 = StateNotifierProvider<Counter, int>((_) => notifier2);
     var buildCount = 0;
     var selectCount = 0;
 
-    Widget build(StateNotifierProvider<Counter> provider) {
+    Widget build(StateNotifierProvider<Counter, int> provider) {
       return ProviderScope(
         child: HookBuilder(builder: (c) {
           buildCount++;
-          final value = useProvider(provider.state.select((value) {
+          final value = useProvider(provider.select((value) {
             selectCount++;
             return value > 5;
           }));
@@ -58,16 +58,16 @@ void main() {
 
   testWidgets('useProvider supports changing the provider', (tester) async {
     final notifier1 = Counter();
-    final provider1 = StateNotifierProvider((_) => notifier1);
+    final provider1 = StateNotifierProvider<Counter, int>((_) => notifier1);
     final notifier2 = Counter(42);
-    final provider2 = StateNotifierProvider((_) => notifier2);
+    final provider2 = StateNotifierProvider<Counter, int>((_) => notifier2);
     var buildCount = 0;
 
-    Widget build(StateNotifierProvider<Counter> provider) {
+    Widget build(StateNotifierProvider<Counter, int> provider) {
       return ProviderScope(
         child: HookBuilder(builder: (c) {
           buildCount++;
-          final value = useProvider(provider.state);
+          final value = useProvider(provider);
           return Text('$value', textDirection: TextDirection.ltr);
         }),
       );
@@ -99,7 +99,7 @@ void main() {
   group('useProvider(provider.select)', () {
     testWidgets('simple flow', (tester) async {
       final notifier = Counter();
-      final provider = StateNotifierProvider((_) => notifier);
+      final provider = StateNotifierProvider<Counter, int>((_) => notifier);
       final selector = SelectorSpy<int>();
       var buildCount = 0;
       Object? lastSelectedValue;
@@ -108,7 +108,7 @@ void main() {
         ProviderScope(
           child: HookBuilder(builder: (c) {
             buildCount++;
-            lastSelectedValue = useProvider(provider.state.select((value) {
+            lastSelectedValue = useProvider(provider.select((value) {
               selector(value);
               return value.isNegative;
             }));
@@ -136,7 +136,7 @@ void main() {
 
     testWidgets('recompute value when changing selector', (tester) async {
       final notifier = Counter();
-      final provider = StateNotifierProvider((_) => notifier);
+      final provider = StateNotifierProvider<Counter, int>((_) => notifier);
       final selector = SelectorSpy<String>();
       String? value2;
       final build = BuildSpy();
@@ -146,7 +146,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(child: HookBuilder(builder: (c) {
           build();
-          lastSelectedValue = useProvider(provider.state.select((value) {
+          lastSelectedValue = useProvider(provider.select((value) {
             selector('$value $value2');
             return '$value $value2';
           }));
@@ -180,7 +180,7 @@ void main() {
     testWidgets('stop calling selectors after one cause rebuild',
         (tester) async {
       final notifier = Counter();
-      final provider = StateNotifierProvider((_) => notifier);
+      final provider = StateNotifierProvider<Counter, int>((_) => notifier);
       bool? lastSelectedValue;
       final selector = SelectorSpy<int>();
       int? lastSelectedValue2;
@@ -192,15 +192,15 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(child: HookBuilder(builder: (c) {
           build();
-          lastSelectedValue = useProvider(provider.state.select((value) {
+          lastSelectedValue = useProvider(provider.select((value) {
             selector(value);
             return value.isNegative;
           }));
-          lastSelectedValue2 = useProvider(provider.state.select((value) {
+          lastSelectedValue2 = useProvider(provider.select((value) {
             selector2(value);
             return value;
           }));
-          lastSelectedValue3 = useProvider(provider.state.select((value) {
+          lastSelectedValue3 = useProvider(provider.select((value) {
             selector3(value);
             return value;
           }));

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Unreleased major]
 
-- **BREAKING CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
-  could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+- **BREAKING CHANGE** The `Listener`/`LocatorMixin` typedefs are removed as the former could cause a name
+  conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
 - **BREAKING CHANGE** The syntax for using `StateNotifierProvider` was updated.
   Before:
 
@@ -33,8 +33,10 @@
 
   See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
 
-- **BREAKING CHANGE** `StateNotifierProvider.overrideWithProvider` is removed. Use `overrideWithValue` instead.
 - **BREAKING CHANGE** It is no-longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
+- feat: Calling `ProviderContainer.dispose` multiple time no-longer throws.
+  This simplifies the tear-off logic of tests.
+- fix: overriding a `StateNotifierProvider`/`ChangeNotifierProvider` with `overrideWithValue` now correctly listens to the notifier.
 
 # 0.13.1
 

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,7 +1,40 @@
 # [Unreleased major]
 
-- **BREAKING-CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
+- **BREAKING CHANGE** Hide the `Listener`/`LocatorMixin` typedefs from `package:state_notifier` as the former
   could cause a name conflict with the widget named `Listener` and the latter is not supported when using Riverpod.
+- **BREAKING CHANGE** The syntax for using `StateNotifierProvider` was updated.
+  Before:
+
+  ```dart
+  class MyStateNotifier extends StateNotifier<MyModel> {...}
+
+  final provider = StateNotifierProvider<MyStateNotifier>((ref) => MyStateNotifier());
+
+  ...
+  Widget build(context, watch) {
+    MyStateNotifier notifier = watch(provider);
+    MyModel model = watch(provider.state);
+  }
+  ```
+
+  After:
+
+  ```dart
+  class MyStateNotifier extends StateNotifier<MyModel> {...}
+
+  final provider = StateNotifierProvider<MyStateNotifier, MyModel>>((ref) => MyStateNotifier());
+
+  ...
+  Widget build(context, watch) {
+    MyStateNotifier notifier = watch(provider.notifier);
+    MyModel model = watch(provider);
+  }
+  ```
+
+  See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
+
+- **BREAKING CHANGE** `StateNotifierProvider.overrideWithProvider` is removed. Use `overrideWithValue` instead.
+- **BREAKING CHANGE** It is no-longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
 
 # 0.13.1
 

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -36,6 +36,8 @@
 - **BREAKING CHANGE** It is no-longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
 - feat: Calling `ProviderContainer.dispose` multiple time no-longer throws.
   This simplifies the tear-off logic of tests.
+- feat: Added `ChangeNotifierProvider.notifier` and `StateProvider.notifier`
+  They allow obtaining the notifier associated to the provider, without causing widgets/providers to rebuild when the state updates. 
 - fix: overriding a `StateNotifierProvider`/`ChangeNotifierProvider` with `overrideWithValue` now correctly listens to the notifier.
 
 # 0.13.1

--- a/packages/riverpod/example/lib/main.dart
+++ b/packages/riverpod/example/lib/main.dart
@@ -21,10 +21,10 @@ import 'package:riverpod/riverpod.dart';
 import 'models.dart';
 
 /// A Provider that reads a json file and decodes it into a [Configuration].
-final configurationProvider = FutureProvider((_) async {
+final configurationProvider = FutureProvider<Configuration>((_) async {
   final file = await File.fromUri(Uri.file('configuration.json')) //
       .readAsString();
-  final map = json.decode(file) as Map<String, dynamic>;
+  final map = json.decode(file) as Map<String, Object?>;
 
   return Configuration.fromJson(map);
 });
@@ -32,7 +32,7 @@ final configurationProvider = FutureProvider((_) async {
 /// Creates a [Repository] from [configurationProvider].
 ///
 /// This will correctly wait until the configurations are available.
-final repositoryProvider = FutureProvider((ref) async {
+final repositoryProvider = FutureProvider<Repository>((ref) async {
   /// Reads the configurations from [configurationProvider]. This is type-safe.
   final configs = await ref.watch(configurationProvider.future);
 

--- a/packages/riverpod/example/lib/models.dart
+++ b/packages/riverpod/example/lib/models.dart
@@ -19,7 +19,7 @@ abstract class Configuration with _$Configuration {
     required String privateKey,
   }) = _Configuration;
 
-  factory Configuration.fromJson(Map<String, dynamic> json) =>
+  factory Configuration.fromJson(Map<String, Object?> json) =>
       _$ConfigurationFromJson(json);
 }
 
@@ -37,9 +37,9 @@ class Repository {
         ))
         .toString();
 
-    final result = await _client.get<Map<String, dynamic>>(
+    final result = await _client.get<Map<String, Object?>>(
       'http://gateway.marvel.com/v1/public/comics',
-      queryParameters: <String, dynamic>{
+      queryParameters: <String, Object?>{
         'ts': timestamp,
         'apikey': _configuration.publicKey,
         'hash': hash,
@@ -63,17 +63,17 @@ class Repository {
 abstract class MarvelResponse with _$MarvelResponse {
   factory MarvelResponse(MarvelData data) = _MarvelResponse;
 
-  factory MarvelResponse.fromJson(Map<String, dynamic> json) =>
+  factory MarvelResponse.fromJson(Map<String, Object?> json) =>
       _$MarvelResponseFromJson(json);
 }
 
 @freezed
 abstract class MarvelData with _$MarvelData {
   factory MarvelData(
-    List<Map<String, dynamic>> results,
+    List<Map<String, Object?>> results,
   ) = _MarvelData;
 
-  factory MarvelData.fromJson(Map<String, dynamic> json) =>
+  factory MarvelData.fromJson(Map<String, Object?> json) =>
       _$MarvelDataFromJson(json);
 }
 
@@ -84,5 +84,5 @@ abstract class Comic with _$Comic {
     required String title,
   }) = _Comic;
 
-  factory Comic.fromJson(Map<String, dynamic> json) => _$ComicFromJson(json);
+  factory Comic.fromJson(Map<String, Object?> json) => _$ComicFromJson(json);
 }

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -52,12 +52,8 @@ export 'src/state_notifier_provider.dart'
     show
         AutoDisposeStateNotifierProvider,
         AutoDisposeStateNotifierProviderFamily,
-        AutoDisposeStateNotifierStateProvider,
         StateNotifierProvider,
-        StateNotifierProviderFamily,
-        StateNotifierStateProvider,
-        AutoDisposeStateNotifierStateProviderX,
-        StateNotifierStateProviderX;
+        StateNotifierProviderFamily;
 
 export 'src/state_provider.dart'
     show

--- a/packages/riverpod/lib/src/builders.dart
+++ b/packages/riverpod/lib/src/builders.dart
@@ -1,3 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+//
+// If you need to modify this file, instead update /tools/generate_providers/bin/generate_providers.dart
+//
+// You can install this utility by executing:
+// dart pub global activate -s path <repository_path>/tools/generate_providers
+//
+// You can then use it in your terminal by executing:
+// generate_providers <riverpod/flutter_riverpod/hooks_riverpod> <path to builder file to update>
+
 import 'package:state_notifier/state_notifier.dart';
 
 import 'internals.dart';
@@ -289,8 +299,8 @@ class StateProviderFamilyBuilder {
   const StateProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  StateProviderFamily<T, Value> call<T, Value>(
-    T Function(ProviderReference ref, Value value) create, {
+  StateProviderFamily<T, Param> call<T, Param>(
+    T Function(ProviderReference ref, Param param) create, {
     String? name,
   }) {
     return StateProviderFamily(create, name: name);
@@ -308,8 +318,9 @@ class StateNotifierProviderBuilder {
   const StateNotifierProviderBuilder();
 
   /// {@macro riverpod.autoDispose}
-  StateNotifierProvider<T> call<T extends StateNotifier<Object?>>(
-    T Function(ProviderReference ref) create, {
+  StateNotifierProvider<Notifier, Value>
+      call<Notifier extends StateNotifier<Value>, Value>(
+    Notifier Function(ProviderReference ref) create, {
     String? name,
   }) {
     return StateNotifierProvider(create, name: name);
@@ -332,9 +343,9 @@ class StateNotifierProviderFamilyBuilder {
   const StateNotifierProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  StateNotifierProviderFamily<T, Value>
-      call<T extends StateNotifier<Object?>, Value>(
-    T Function(ProviderReference ref, Value value) create, {
+  StateNotifierProviderFamily<Notifier, Value, Param>
+      call<Notifier extends StateNotifier<Value>, Value, Param>(
+    Notifier Function(ProviderReference ref, Param param) create, {
     String? name,
   }) {
     return StateNotifierProviderFamily(create, name: name);
@@ -376,8 +387,8 @@ class ProviderFamilyBuilder {
   const ProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  ProviderFamily<T, Value> call<T, Value>(
-    T Function(ProviderReference ref, Value value) create, {
+  ProviderFamily<T, Param> call<T, Param>(
+    T Function(ProviderReference ref, Param param) create, {
     String? name,
   }) {
     return ProviderFamily(create, name: name);
@@ -419,8 +430,8 @@ class FutureProviderFamilyBuilder {
   const FutureProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  FutureProviderFamily<T, Value> call<T, Value>(
-    Future<T> Function(ProviderReference ref, Value value) create, {
+  FutureProviderFamily<T, Param> call<T, Param>(
+    Future<T> Function(ProviderReference ref, Param param) create, {
     String? name,
   }) {
     return FutureProviderFamily(create, name: name);
@@ -462,8 +473,8 @@ class StreamProviderFamilyBuilder {
   const StreamProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  StreamProviderFamily<T, Value> call<T, Value>(
-    Stream<T> Function(ProviderReference ref, Value value) create, {
+  StreamProviderFamily<T, Param> call<T, Param>(
+    Stream<T> Function(ProviderReference ref, Param param) create, {
     String? name,
   }) {
     return StreamProviderFamily(create, name: name);
@@ -500,8 +511,8 @@ class AutoDisposeStateProviderFamilyBuilder {
   const AutoDisposeStateProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  AutoDisposeStateProviderFamily<T, Value> call<T, Value>(
-    T Function(AutoDisposeProviderReference ref, Value value) create, {
+  AutoDisposeStateProviderFamily<T, Param> call<T, Param>(
+    T Function(AutoDisposeProviderReference ref, Param param) create, {
     String? name,
   }) {
     return AutoDisposeStateProviderFamily(create, name: name);
@@ -514,8 +525,9 @@ class AutoDisposeStateNotifierProviderBuilder {
   const AutoDisposeStateNotifierProviderBuilder();
 
   /// {@macro riverpod.autoDispose}
-  AutoDisposeStateNotifierProvider<T> call<T extends StateNotifier<Object?>>(
-    T Function(AutoDisposeProviderReference ref) create, {
+  AutoDisposeStateNotifierProvider<Notifier, Value>
+      call<Notifier extends StateNotifier<Value>, Value>(
+    Notifier Function(AutoDisposeProviderReference ref) create, {
     String? name,
   }) {
     return AutoDisposeStateNotifierProvider(create, name: name);
@@ -533,9 +545,9 @@ class AutoDisposeStateNotifierProviderFamilyBuilder {
   const AutoDisposeStateNotifierProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  AutoDisposeStateNotifierProviderFamily<T, Value>
-      call<T extends StateNotifier<Object?>, Value>(
-    T Function(AutoDisposeProviderReference ref, Value value) create, {
+  AutoDisposeStateNotifierProviderFamily<Notifier, Value, Param>
+      call<Notifier extends StateNotifier<Value>, Value, Param>(
+    Notifier Function(AutoDisposeProviderReference ref, Param param) create, {
     String? name,
   }) {
     return AutoDisposeStateNotifierProviderFamily(create, name: name);
@@ -567,8 +579,8 @@ class AutoDisposeProviderFamilyBuilder {
   const AutoDisposeProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  AutoDisposeProviderFamily<T, Value> call<T, Value>(
-    T Function(AutoDisposeProviderReference ref, Value value) create, {
+  AutoDisposeProviderFamily<T, Param> call<T, Param>(
+    T Function(AutoDisposeProviderReference ref, Param param) create, {
     String? name,
   }) {
     return AutoDisposeProviderFamily(create, name: name);
@@ -600,8 +612,8 @@ class AutoDisposeFutureProviderFamilyBuilder {
   const AutoDisposeFutureProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  AutoDisposeFutureProviderFamily<T, Value> call<T, Value>(
-    Future<T> Function(AutoDisposeProviderReference ref, Value value) create, {
+  AutoDisposeFutureProviderFamily<T, Param> call<T, Param>(
+    Future<T> Function(AutoDisposeProviderReference ref, Param param) create, {
     String? name,
   }) {
     return AutoDisposeFutureProviderFamily(create, name: name);
@@ -633,8 +645,8 @@ class AutoDisposeStreamProviderFamilyBuilder {
   const AutoDisposeStreamProviderFamilyBuilder();
 
   /// {@macro riverpod.family}
-  AutoDisposeStreamProviderFamily<T, Value> call<T, Value>(
-    Stream<T> Function(AutoDisposeProviderReference ref, Value value) create, {
+  AutoDisposeStreamProviderFamily<T, Param> call<T, Param>(
+    Stream<T> Function(AutoDisposeProviderReference ref, Param param) create, {
     String? name,
   }) {
     return AutoDisposeStreamProviderFamily(create, name: name);

--- a/packages/riverpod/lib/src/framework/auto_dispose.dart
+++ b/packages/riverpod/lib/src/framework/auto_dispose.dart
@@ -30,23 +30,14 @@ abstract class AutoDisposeProviderReference extends ProviderReference {
 abstract class AutoDisposeProviderBase<Created, Listened>
     extends RootProvider<Created, Listened> {
   /// {@macro riverpod.AutoDisposeProviderBase}
-  AutoDisposeProviderBase(
-    Created Function(AutoDisposeProviderReference ref) create,
-    String? name,
-  ) : super((ref) => create(ref as AutoDisposeProviderReference), name);
+  AutoDisposeProviderBase(String? name) : super(name);
+
+  @override
+  Created create(covariant AutoDisposeProviderReference ref);
 
   @override
   AutoDisposeProviderElement<Created, Listened> createElement() {
     return AutoDisposeProviderElement(this);
-  }
-
-  /// Overrides the behavior of this provider with another provider.
-  ///
-  /// {@macro riverpod.overideWith}
-  ProviderOverride overrideWithProvider(
-    RootProvider<Created, Listened> provider,
-  ) {
-    return ProviderOverride(provider, this);
   }
 }
 

--- a/packages/riverpod/lib/src/framework/base_provider.dart
+++ b/packages/riverpod/lib/src/framework/base_provider.dart
@@ -960,12 +960,10 @@ $stackTrace
 
 @protected
 mixin ProviderOverridesMixin<Created, Listened>
-    on ProviderBase<Created, Listened> {
+    on AlwaysAliveProviderBase<Created, Listened> {
   /// Overrides the behavior of a provider with a value.
   ///
   /// {@macro riverpod.overideWith}
-  // Works only on RootProvider<T, T> scenario by default
-  // TODO support ChangeNotifier/StateNotifier
   Override overrideWithValue(Listened value) {
     return ProviderOverride(
       ValueProvider<Object?, Listened>((ref) => value, value),
@@ -1003,7 +1001,30 @@ mixin ProviderOverridesMixin<Created, Listened>
   /// {@endtemplate}
   // Cannot be overridden by AutoDisposeProviders
   ProviderOverride overrideWithProvider(
-    ProviderBase<Object?, Listened> provider,
+    AlwaysAliveProviderBase<Object?, Listened> provider,
+  ) {
+    return ProviderOverride(provider, this);
+  }
+}
+
+@protected
+mixin AutoDisposeProviderOverridesMixin<Created, Listened>
+    on AutoDisposeProviderBase<Created, Listened> {
+  /// Overrides the behavior of a provider with a value.
+  ///
+  /// {@macro riverpod.overideWith}
+  Override overrideWithValue(Listened value) {
+    return ProviderOverride(
+      ValueProvider<Object?, Listened>((ref) => value, value),
+      this,
+    );
+  }
+
+  /// Overrides the behavior of this provider with another provider.
+  ///
+  /// {@macro riverpod.overideWith}
+  ProviderOverride overrideWithProvider(
+    AutoDisposeProviderBase<Object?, Listened> provider,
   ) {
     return ProviderOverride(provider, this);
   }

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -358,9 +358,7 @@ class ProviderContainer {
   /// [ProviderContainer] and call [ProviderReference.onDispose] listeners.
   void dispose() {
     if (_disposed) {
-      throw StateError(
-        'Called disposed on a ProviderContainer that was already disposed',
-      );
+      return;
     }
     if (_children.isNotEmpty) {
       throw StateError(

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -486,7 +486,7 @@ abstract class ProviderObserver {
 /// See also:
 ///
 /// - [ProviderContainer], which uses this object.
-/// - [AlwaysAliveProviderBase.overrideWithProvider], which creates a [ProviderOverride].
+/// - `overrideWithProvider`/`overrideWithValue`, which creates a [ProviderOverride].
 @sealed
 class ProviderOverride implements Override {
   /// Internal use only

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -225,7 +225,7 @@ class ProviderContainer {
   ///
   /// If you are using flutter, this is done implicitly for you by `ProviderScope`.
   ///
-  /// Updating a [RootProvider.overrideWithValue] with a different value
+  /// Updating a `overrideWithValue` with a different value
   /// will cause the listeners to rebuild.
   ///
   /// It is not possible, to remove or add new overrides, only update existing ones.

--- a/packages/riverpod/lib/src/framework/family.dart
+++ b/packages/riverpod/lib/src/framework/family.dart
@@ -4,10 +4,15 @@ part of '../framework.dart';
 abstract class Family<Created, Listened, Param, Ref extends ProviderReference,
     P extends RootProvider<Created, Listened>> {
   /// A base class for all *Family variants of providers.
-  Family(this._builder, this._name);
+  Family(this.builder, this.name);
 
-  final Created Function(Ref ref, Param param) _builder;
-  final String? _name;
+  /// Implementation detail. Do not use.
+  @protected
+  final Created Function(Ref ref, Param param) builder;
+
+  /// Implementation detail. Do not use.
+  @protected
+  final String? name;
 
   final _cache = <Param, P>{};
 
@@ -18,7 +23,7 @@ abstract class Family<Created, Listened, Param, Ref extends ProviderReference,
   P call(Param value) {
     return _cache.putIfAbsent(value, () {
       final provider =
-          create(value, _builder, _name == null ? null : '$_name ($value)');
+          create(value, builder, name == null ? null : '$name ($value)');
       assert(
         provider._from == null,
         'The provider created already belongs to a Family',
@@ -62,9 +67,7 @@ extension FamilyX<Created, Listened, Param, Ref extends ProviderReference,
   ) {
     return FamilyOverride(
       this,
-      (dynamic param) {
-        return create(param as Param, builderOverride, null);
-      },
+      (param) => create(param as Param, builderOverride, null),
     );
   }
 }
@@ -75,6 +78,6 @@ class FamilyOverride implements Override {
   /// Do not use
   FamilyOverride(this._family, this._createOverride);
 
-  final RootProvider Function(dynamic param) _createOverride;
+  final RootProvider Function(Object? param) _createOverride;
   final Family _family;
 }

--- a/packages/riverpod/lib/src/framework/scoped_provider.dart
+++ b/packages/riverpod/lib/src/framework/scoped_provider.dart
@@ -95,15 +95,24 @@ typedef ScopedCreate<T> = T Function(ScopedReader watch);
 class ScopedProvider<Listened> extends ProviderBase<Listened, Listened> {
   /// {@macro riverpod.scopedprovider}
   ScopedProvider(
-    ScopedCreate<Listened>? create, {
+    this._create, {
     String? name,
   }) : super(
-          create == null
-              ? (ref) => throw UnsupportedError(
-                  'No default behavior specified for ScopedProvider<$Listened>')
-              : (ref) => create((ref as _ScopedProviderElement).watch),
           name,
         );
+
+  final Listened Function(ScopedReader watch)? _create;
+
+  @override
+  Listened create(covariant _ScopedProviderElement ref) {
+    if (_create == null) {
+      throw UnsupportedError(
+        'No default behavior specified for ScopedProvider<$Listened>',
+      );
+    }
+
+    return _create!(ref.watch);
+  }
 
   @override
   _ScopedProviderElement<Listened> createElement() {

--- a/packages/riverpod/lib/src/framework/value_provider.dart
+++ b/packages/riverpod/lib/src/framework/value_provider.dart
@@ -2,18 +2,18 @@ part of '../framework.dart';
 
 /// A provider that is driven by a value instead of a function.
 ///
-/// This is an implementation detail of [RootProvider.overrideWithValue].
+/// This is an implementation detail of `overrideWithValue`.
 @sealed
 class ValueProvider<Created, Listened>
     extends AlwaysAliveProviderBase<Created, Listened> {
   /// Creates a [ValueProvider].
-  ValueProvider(
-    Created Function(ValueProviderElement<Created, Listened> ref) create,
-    this._value,
-  ) : super(
-          (ref) => create(ref as ValueProviderElement<Created, Listened>),
-          null,
-        );
+  ValueProvider(this._create, this._value) : super(null);
+
+  final Created Function(ValueProviderElement<Created, Listened> ref) _create;
+
+  @override
+  Created create(covariant ValueProviderElement<Created, Listened> ref) =>
+      _create(ref);
 
   final Listened _value;
 
@@ -26,11 +26,6 @@ class ValueProvider<Created, Listened>
   ValueProviderElement<Created, Listened> createElement() {
     return ValueProviderElement(this);
   }
-
-  @override
-  Override overrideWithValue(Listened value) {
-    throw UnimplementedError();
-  }
 }
 
 /// The [ProviderElement] of a [ValueProvider]
@@ -42,7 +37,7 @@ class ValueProviderElement<Created, Listened>
     ValueProvider<Created, Listened> provider,
   ) : super(provider);
 
-  /// A custom listener called when [RootProvider.overrideWithValue] changes
+  /// A custom listener called when `overrideWithValue` changes
   /// with a different value.
   void Function(Listened value)? onChange;
 

--- a/packages/riverpod/lib/src/future_provider.dart
+++ b/packages/riverpod/lib/src/future_provider.dart
@@ -43,7 +43,7 @@ part 'future_provider/base.dart';
 /// final configProvider = FutureProvider<Configuration>((ref) async {
 ///   final content = json.decode(
 ///     await rootBundle.loadString('assets/configurations.json'),
-///   ) as Map<String, dynamic>;
+///   ) as Map<String, Object?>;
 ///
 ///   return Configuration.fromJson(content);
 /// });
@@ -79,7 +79,6 @@ part 'future_provider/base.dart';
 /// - [FutureProvider.autoDispose], to destroy the state of a [FutureProvider] when no-longer needed.
 /// {@endtemplate}
 mixin _FutureProviderMixin<T> on RootProvider<Future<T>, AsyncValue<T>> {
-  @override
   Override overrideWithValue(AsyncValue<T> value) {
     return ProviderOverride(
       ValueProvider<Future<T>, AsyncValue<T>>((ref) {

--- a/packages/riverpod/lib/src/future_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/future_provider/auto_dispose.dart
@@ -5,7 +5,7 @@ part of '../future_provider.dart';
 class AutoDisposeFutureProvider<T>
     extends AutoDisposeProviderBase<Future<T>, AsyncValue<T>>
     with
-        ProviderOverridesMixin<Future<T>, AsyncValue<T>>,
+        AutoDisposeProviderOverridesMixin<Future<T>, AsyncValue<T>>,
         _FutureProviderMixin<T> {
   /// {@macro riverpod.futureprovider}
   AutoDisposeFutureProvider(this._create, {String? name}) : super(name);

--- a/packages/riverpod/lib/src/future_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/future_provider/auto_dispose.dart
@@ -4,12 +4,16 @@ part of '../future_provider.dart';
 @sealed
 class AutoDisposeFutureProvider<T>
     extends AutoDisposeProviderBase<Future<T>, AsyncValue<T>>
-    with _FutureProviderMixin<T> {
+    with
+        ProviderOverridesMixin<Future<T>, AsyncValue<T>>,
+        _FutureProviderMixin<T> {
   /// {@macro riverpod.futureprovider}
-  AutoDisposeFutureProvider(
-    Create<Future<T>, AutoDisposeProviderReference> create, {
-    String? name,
-  }) : super(create, name);
+  AutoDisposeFutureProvider(this._create, {String? name}) : super(name);
+
+  final Create<Future<T>, AutoDisposeProviderReference> _create;
+
+  @override
+  Future<T> create(covariant AutoDisposeProviderReference ref) => _create(ref);
 
   /// {@macro riverpod.family}
   static const family = AutoDisposeFutureProviderFamilyBuilder();

--- a/packages/riverpod/lib/src/future_provider/base.dart
+++ b/packages/riverpod/lib/src/future_provider/base.dart
@@ -4,12 +4,16 @@ part of '../future_provider.dart';
 @sealed
 class FutureProvider<T>
     extends AlwaysAliveProviderBase<Future<T>, AsyncValue<T>>
-    with _FutureProviderMixin<T> {
+    with
+        ProviderOverridesMixin<Future<T>, AsyncValue<T>>,
+        _FutureProviderMixin<T> {
   /// {@macro riverpod.futureprovider}
-  FutureProvider(
-    Create<Future<T>, ProviderReference> create, {
-    String? name,
-  }) : super(create, name);
+  FutureProvider(this._create, {String? name}) : super(name);
+
+  final Create<Future<T>, ProviderReference> _create;
+
+  @override
+  Future<T> create(covariant ProviderReference ref) => _create(ref);
 
   /// {@macro riverpod.family}
   static const family = FutureProviderFamilyBuilder();

--- a/packages/riverpod/lib/src/provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/provider/auto_dispose.dart
@@ -2,20 +2,18 @@ part of '../provider.dart';
 
 /// {@macro riverpod.provider}
 @sealed
-class AutoDisposeProvider<T> extends AutoDisposeProviderBase<T, T> {
+class AutoDisposeProvider<T> extends AutoDisposeProviderBase<T, T>
+    with ProviderOverridesMixin<T, T> {
   /// {@macro riverpod.provider}
-  AutoDisposeProvider(
-    Create<T, AutoDisposeProviderReference> create, {
-    String? name,
-  }) : super(create, name);
+  AutoDisposeProvider(this._create, {String? name}) : super(name);
 
   /// {@macro riverpod.family}
   static const family = AutoDisposeProviderFamilyBuilder();
 
+  final Create<T, AutoDisposeProviderReference> _create;
+
   @override
-  ProviderOverride overrideWithProvider(RootProvider<Object?, T> provider) {
-    return ProviderOverride(provider, this);
-  }
+  T create(covariant AutoDisposeProviderReference ref) => _create(ref);
 
   @override
   _AutoDisposeProviderState<T> createState() => _AutoDisposeProviderState();

--- a/packages/riverpod/lib/src/provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/provider/auto_dispose.dart
@@ -3,7 +3,7 @@ part of '../provider.dart';
 /// {@macro riverpod.provider}
 @sealed
 class AutoDisposeProvider<T> extends AutoDisposeProviderBase<T, T>
-    with ProviderOverridesMixin<T, T> {
+    with AutoDisposeProviderOverridesMixin<T, T> {
   /// {@macro riverpod.provider}
   AutoDisposeProvider(this._create, {String? name}) : super(name);
 

--- a/packages/riverpod/lib/src/provider/base.dart
+++ b/packages/riverpod/lib/src/provider/base.dart
@@ -2,12 +2,13 @@ part of '../provider.dart';
 
 /// {@macro riverpod.provider}
 @sealed
-class Provider<T> extends AlwaysAliveProviderBase<T, T> {
+class Provider<T> extends AlwaysAliveProviderBase<T, T>
+    with ProviderOverridesMixin<T, T> {
   /// {@macro riverpod.provider}
   Provider(
-    Create<T, ProviderReference> create, {
+    this._create, {
     String? name,
-  }) : super(create, name);
+  }) : super(name);
 
   /// {@macro riverpod.family}
   static const family = ProviderFamilyBuilder();
@@ -15,10 +16,10 @@ class Provider<T> extends AlwaysAliveProviderBase<T, T> {
   /// {@macro riverpod.autoDispose}
   static const autoDispose = AutoDisposeProviderBuilder();
 
+  final Create<T, ProviderReference> _create;
+
   @override
-  ProviderOverride overrideWithProvider(RootProvider<Object?, T> provider) {
-    return ProviderOverride(provider, this);
-  }
+  T create(ProviderReference ref) => _create(ref);
 
   @override
   _ProviderState<T> createState() => _ProviderState();

--- a/packages/riverpod/lib/src/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider.dart
@@ -57,7 +57,7 @@ part 'state_notifier_provider/base.dart';
 /// ```dart
 /// Widget build(BuildContext context, ScopedReader watch) {
 ///   // rebuild the widget when the todo list changes
-///   List<Todo> todos = watch(todosProvider.state);
+///   List<Todo> todos = watch(todosProvider);
 ///
 ///   return ListView(
 ///     children: [

--- a/packages/riverpod/lib/src/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider.dart
@@ -1,5 +1,4 @@
 import 'package:meta/meta.dart';
-import 'package:riverpod/src/created_provider.dart';
 import 'package:state_notifier/state_notifier.dart';
 
 import 'builders.dart';
@@ -7,8 +6,8 @@ import 'framework.dart';
 import 'future_provider.dart';
 import 'provider.dart';
 
-part 'state_notifier_provider/base.dart';
 part 'state_notifier_provider/auto_dispose.dart';
+part 'state_notifier_provider/base.dart';
 
 /// {@template riverpod.statenotifierprovider}
 /// Creates a [StateNotifier] and expose its current state.
@@ -97,5 +96,20 @@ class _StateNotifierProviderState<Notifier extends StateNotifier<Value>, Value>
   void dispose() {
     removeListener?.call();
     super.dispose();
+  }
+}
+
+mixin _StateNotifierProviderMixin<Notifier extends StateNotifier<Value>, Value>
+    on RootProvider<Notifier, Value> {
+  ProviderBase<Notifier, Notifier> get notifier;
+
+  /// Overrides the behavior of a provider with a value.
+  ///
+  /// {@macro riverpod.overideWith}
+  Override overrideWithValue(Notifier value) {
+    return ProviderOverride(
+      ValueProvider<Object?, Notifier>((ref) => value, value),
+      notifier,
+    );
   }
 }

--- a/packages/riverpod/lib/src/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:riverpod/src/created_provider.dart';
 import 'package:state_notifier/state_notifier.dart';
 
 import 'builders.dart';
@@ -73,12 +74,13 @@ part 'state_notifier_provider/auto_dispose.dart';
 /// }
 /// ```
 /// {@endtemplate}
-mixin _StateNotifierStateProviderStateMixin<T>
-    on ProviderStateBase<StateNotifier<T>, T> {
+
+class _StateNotifierProviderState<Notifier extends StateNotifier<Value>, Value>
+    extends ProviderStateBase<Notifier, Value> {
   void Function()? removeListener;
 
   @override
-  void valueChanged({StateNotifier<T>? previous}) {
+  void valueChanged({Notifier? previous}) {
     if (createdValue == previous) {
       return;
     }
@@ -87,7 +89,7 @@ mixin _StateNotifierStateProviderStateMixin<T>
   }
 
   // ignore: use_setters_to_change_properties
-  void _listener(T value) {
+  void _listener(Value value) {
     exposedValue = value;
   }
 

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -2,72 +2,48 @@ part of '../state_notifier_provider.dart';
 
 /// {@macro riverpod.statenotifierprovider}
 @sealed
-class AutoDisposeStateNotifierProvider<T extends StateNotifier<Object?>>
-    extends AutoDisposeProvider<T> {
+class AutoDisposeStateNotifierProvider<Notifier extends StateNotifier<Value>,
+    Value> extends AutoDisposeProviderBase<Notifier, Value> {
   /// {@macro riverpod.statenotifierprovider}
   AutoDisposeStateNotifierProvider(
-    Create<T, AutoDisposeProviderReference> create, {
+    Create<Notifier, AutoDisposeProviderReference> create, {
     String? name,
-  }) : super((ref) {
-          final controller = create(ref);
-          ref.onDispose(controller.dispose);
-          return controller;
-        }, name: name);
+  }) : super(create, name);
+
+  // TODO name
+  late final RootProvider<Notifier, Notifier> notifier =
+      AutoDisposeCreatedProvider(this);
 
   /// {@macro riverpod.family}
   static const family = AutoDisposeStateNotifierProviderFamilyBuilder();
 
-  AutoDisposeStateNotifierStateProvider<Object?>? _state;
-}
-
-/// Adds [state] to [StateNotifierProvider.autoDispose].
-extension AutoDisposeStateNotifierStateProviderX<Value>
-    on AutoDisposeStateNotifierProvider<StateNotifier<Value>> {
-  /// {@macro riverpod.statenotifierprovider.state.provider}
-  AutoDisposeStateNotifierStateProvider<Value> get state {
-    _state ??= AutoDisposeStateNotifierStateProvider<Value>._(this);
-    // ignore: cast_nullable_to_non_nullable, confirmed to be non-null. This avoids one operation
-    return _state as AutoDisposeStateNotifierStateProvider<Value>;
-  }
-}
-
-/// {@macro riverpod.statenotifierprovider.state.provider}
-@sealed
-class AutoDisposeStateNotifierStateProvider<T>
-    extends AutoDisposeProviderBase<StateNotifier<T>, T> {
-  AutoDisposeStateNotifierStateProvider._(
-      AutoDisposeStateNotifierProvider<StateNotifier<T>> provider)
-      : super(
-          (ref) => ref.watch(provider),
-          provider.name != null ? '${provider.name}.state' : null,
-        );
+  /// {@macro riverpod.autoDispose}
+  static const autoDispose = AutoDisposeStateNotifierProviderBuilder();
 
   @override
-  _AutoDisposeStateNotifierStateProviderState<T> createState() {
-    return _AutoDisposeStateNotifierStateProviderState<T>();
+  _StateNotifierProviderState<Notifier, Value> createState() {
+    return _StateNotifierProviderState<Notifier, Value>();
   }
 }
 
+/// {@template riverpod.statenotifierprovider.family}
+/// A class that allows building a [StateNotifierProvider] from an external parameter.
+/// {@endtemplate}
 @sealed
-class _AutoDisposeStateNotifierStateProviderState<T> = ProviderStateBase<
-    StateNotifier<T>, T> with _StateNotifierStateProviderStateMixin<T>;
-
-/// {@macro riverpod.statenotifierprovider.family}
-@sealed
-class AutoDisposeStateNotifierProviderFamily<T extends StateNotifier<Object?>,
-        A>
-    extends Family<T, T, A, AutoDisposeProviderReference,
-        AutoDisposeStateNotifierProvider<T>> {
+class AutoDisposeStateNotifierProviderFamily<
+        Notifier extends StateNotifier<Value>, Value, Param>
+    extends Family<Notifier, Value, Param, AutoDisposeProviderReference,
+        AutoDisposeStateNotifierProvider<Notifier, Value>> {
   /// {@macro riverpod.statenotifierprovider.family}
   AutoDisposeStateNotifierProviderFamily(
-    T Function(AutoDisposeProviderReference ref, A a) create, {
+    Notifier Function(AutoDisposeProviderReference ref, Param a) create, {
     String? name,
   }) : super(create, name);
 
   @override
-  AutoDisposeStateNotifierProvider<T> create(
-    A value,
-    T Function(AutoDisposeProviderReference ref, A param) builder,
+  AutoDisposeStateNotifierProvider<Notifier, Value> create(
+    Param value,
+    Notifier Function(AutoDisposeProviderReference ref, Param param) builder,
     String? name,
   ) {
     return AutoDisposeStateNotifierProvider(

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -45,7 +45,7 @@ class AutoDisposeStateNotifierProvider<Notifier extends StateNotifier<Value>,
   /// Overrides the behavior of a provider with a another provider.
   ///
   /// {@macro riverpod.overideWith}
-  Override overrideWitProvider(
+  Override overrideWithProvider(
     AutoDisposeStateNotifierProvider<Notifier, Value> provider,
   ) {
     return ProviderOverride(provider.notifier, notifier);

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -1,24 +1,51 @@
 part of '../state_notifier_provider.dart';
 
+class _AutoDisposeNotifierProvider<Notifier extends StateNotifier<Object?>>
+    extends AutoDisposeProvider<Notifier> {
+  _AutoDisposeNotifierProvider(
+    Create<Notifier, AutoDisposeProviderReference> create, {
+    required String? name,
+  }) : super(
+          (ref) {
+            final notifier = create(ref);
+            ref.onDispose(notifier.dispose);
+            return notifier;
+          },
+          name: name == null ? null : '$name.notifier',
+        );
+}
+
 /// {@macro riverpod.statenotifierprovider}
 @sealed
 class AutoDisposeStateNotifierProvider<Notifier extends StateNotifier<Value>,
-    Value> extends AutoDisposeProviderBase<Notifier, Value> {
+        Value> extends AutoDisposeProviderBase<Notifier, Value>
+    with _StateNotifierProviderMixin<Notifier, Value> {
   /// {@macro riverpod.statenotifierprovider}
-  AutoDisposeStateNotifierProvider(
-    Create<Notifier, AutoDisposeProviderReference> create, {
-    String? name,
-  }) : super(create, name);
-
-  // TODO name
-  late final RootProvider<Notifier, Notifier> notifier =
-      AutoDisposeCreatedProvider(this);
+  AutoDisposeStateNotifierProvider(this._create, {String? name}) : super(name);
 
   /// {@macro riverpod.family}
   static const family = AutoDisposeStateNotifierProviderFamilyBuilder();
 
   /// {@macro riverpod.autoDispose}
   static const autoDispose = AutoDisposeStateNotifierProviderBuilder();
+
+  final Create<Notifier, AutoDisposeProviderReference> _create;
+
+  @override
+  AutoDisposeStateNotifierProviderFamily<Notifier, Value, Object?>? get from =>
+      super.from
+          as AutoDisposeStateNotifierProviderFamily<Notifier, Value, Object?>?;
+
+  // TODO name
+  @override
+  late final AutoDisposeProviderBase<Notifier, Notifier> notifier = from != null
+      ? from!._notifierFamily(argument)
+      : _AutoDisposeNotifierProvider(_create, name: name);
+
+  @override
+  Notifier create(covariant AutoDisposeProviderReference ref) {
+    return ref.watch(notifier);
+  }
 
   @override
   _StateNotifierProviderState<Notifier, Value> createState() {
@@ -47,6 +74,45 @@ class AutoDisposeStateNotifierProviderFamily<
     String? name,
   ) {
     return AutoDisposeStateNotifierProvider(
+      (ref) => builder(ref, value),
+      name: name,
+    );
+  }
+
+  late final _notifierFamily =
+      _AutoDisposeNotifierFamily<Notifier, Param>(builder, name);
+
+  /// Overrides the behavior of a family for a part of the application.
+  ///
+  /// {@macro riverpod.overideWith}
+  Override overrideWithProvider(
+    Notifier Function(ProviderReference ref, Param param) builderOverride,
+  ) {
+    return FamilyOverride(
+      _notifierFamily,
+      (param) {
+        return _notifierFamily.create(param as Param, builderOverride, null);
+      },
+    );
+  }
+}
+
+@sealed
+class _AutoDisposeNotifierFamily<Notifier extends StateNotifier<Object?>, Param>
+    extends Family<Notifier, Notifier, Param, AutoDisposeProviderReference,
+        _AutoDisposeNotifierProvider<Notifier>> {
+  _AutoDisposeNotifierFamily(
+    Notifier Function(AutoDisposeProviderReference ref, Param param) builder,
+    String? name,
+  ) : super(builder, name);
+
+  @override
+  _AutoDisposeNotifierProvider<Notifier> create(
+    Param value,
+    Notifier Function(AutoDisposeProviderReference ref, Param param) builder,
+    String? name,
+  ) {
+    return _AutoDisposeNotifierProvider(
       (ref) => builder(ref, value),
       name: name,
     );

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -42,6 +42,15 @@ class AutoDisposeStateNotifierProvider<Notifier extends StateNotifier<Value>,
       ? from!._notifierFamily(argument)
       : _AutoDisposeNotifierProvider(_create, name: name);
 
+  /// Overrides the behavior of a provider with a another provider.
+  ///
+  /// {@macro riverpod.overideWith}
+  Override overrideWitProvider(
+    AutoDisposeStateNotifierProvider<Notifier, Value> provider,
+  ) {
+    return ProviderOverride(provider.notifier, notifier);
+  }
+
   @override
   Notifier create(covariant AutoDisposeProviderReference ref) {
     return ref.watch(notifier);

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -36,7 +36,7 @@ class AutoDisposeStateNotifierProvider<Notifier extends StateNotifier<Value>,
       super.from
           as AutoDisposeStateNotifierProviderFamily<Notifier, Value, Object?>?;
 
-  // TODO name
+  /// {@macro riverpod.statenotifierprovider.notifier}
   @override
   late final AutoDisposeProviderBase<Notifier, Notifier> notifier = from != null
       ? from!._notifierFamily(argument)

--- a/packages/riverpod/lib/src/state_notifier_provider/base.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/base.dart
@@ -41,6 +41,15 @@ class StateNotifierProvider<Notifier extends StateNotifier<Value>, Value>
       ? from!._notifierFamily(argument)
       : _NotifierProvider(_create, name: name);
 
+  /// Overrides the behavior of a provider with a another provider.
+  ///
+  /// {@macro riverpod.overideWith}
+  Override overrideWitProvider(
+    StateNotifierProvider<Notifier, Value> provider,
+  ) {
+    return ProviderOverride(provider.notifier, notifier);
+  }
+
   @override
   Notifier create(ProviderReference ref) => ref.watch(notifier);
 

--- a/packages/riverpod/lib/src/state_notifier_provider/base.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/base.dart
@@ -35,7 +35,13 @@ class StateNotifierProvider<Notifier extends StateNotifier<Value>, Value>
   StateNotifierProviderFamily<Notifier, Value, Object?>? get from =>
       super.from as StateNotifierProviderFamily<Notifier, Value, Object?>?;
 
-  // TODO name
+  /// {@template riverpod.statenotifierprovider.notifier}
+  /// Obtains the [StateNotifier] associated with this [StateNotifierProvider],
+  /// without listening to it.
+  ///
+  /// Listening to this provider may cause providers/widgets to rebuild in the
+  /// event that the [StateNotifier] it recreated.
+  /// {@endtemplate}
   @override
   late final AlwaysAliveProviderBase<Notifier, Notifier> notifier = from != null
       ? from!._notifierFamily(argument)

--- a/packages/riverpod/lib/src/state_notifier_provider/base.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/base.dart
@@ -44,7 +44,7 @@ class StateNotifierProvider<Notifier extends StateNotifier<Value>, Value>
   /// Overrides the behavior of a provider with a another provider.
   ///
   /// {@macro riverpod.overideWith}
-  Override overrideWitProvider(
+  Override overrideWithProvider(
     StateNotifierProvider<Notifier, Value> provider,
   ) {
     return ProviderOverride(provider.notifier, notifier);

--- a/packages/riverpod/lib/src/state_provider.dart
+++ b/packages/riverpod/lib/src/state_provider.dart
@@ -38,7 +38,7 @@ class StateController<T> extends StateNotifier<T> {
 /// final productsProvider = StateNotifierProvider<ProductsNotifier>((ref) => ProductsNotifier());
 ///
 /// Widget build(BuildContext context, ScopedReader watch) {
-///   final List<Product> products = watch(productsProvider.state);
+///   final List<Product> products = watch(productsProvider);
 ///   final selectedProductId = watch(selectedProductIdProvider);
 ///
 ///   return ListView(

--- a/packages/riverpod/lib/src/state_provider.dart
+++ b/packages/riverpod/lib/src/state_provider.dart
@@ -1,11 +1,12 @@
 import 'package:meta/meta.dart';
 import 'package:state_notifier/state_notifier.dart';
 
+import '../riverpod.dart';
 import 'builders.dart';
 import 'framework.dart';
 
-part 'state_provider/base.dart';
 part 'state_provider/auto_dispose.dart';
+part 'state_provider/base.dart';
 
 /// A [StateNotifier] that allows modifying its [state] from outside.
 ///

--- a/packages/riverpod/lib/src/state_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_provider/auto_dispose.dart
@@ -10,6 +10,7 @@ class AutoDisposeStateProvider<T>
     String? name,
   }) : super(name);
 
+  /// {@macro riverpod.stateprovider.notifier}
   late final AutoDisposeProviderBase<StateController<T>, StateController<T>>
       notifier = AutoDisposeProvider((ref) => ref.watch(this));
 

--- a/packages/riverpod/lib/src/state_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_provider/auto_dispose.dart
@@ -6,9 +6,16 @@ class AutoDisposeStateProvider<T>
     extends AutoDisposeProviderBase<StateController<T>, StateController<T>> {
   /// {@macro riverpod.stateprovider}
   AutoDisposeStateProvider(
-    Create<T, AutoDisposeProviderReference> create, {
+    this._create, {
     String? name,
-  }) : super((ref) => StateController(create(ref)), name);
+  }) : super(name);
+
+  final Create<T, AutoDisposeProviderReference> _create;
+
+  @override
+  StateController<T> create(AutoDisposeProviderReference ref) {
+    return StateController(_create(ref));
+  }
 
   @override
   _AutoDisposeStateProviderState<T> createState() {
@@ -62,7 +69,7 @@ extension AutoDisposeStateFamilyX<T, Param> on Family<
   ) {
     return FamilyOverride(
       this,
-      (dynamic param) {
+      (param) {
         return create(
           param as Param,
           (ref, a) => StateController(builderOverride(ref, a)),

--- a/packages/riverpod/lib/src/state_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_provider/auto_dispose.dart
@@ -10,6 +10,9 @@ class AutoDisposeStateProvider<T>
     String? name,
   }) : super(name);
 
+  late final AutoDisposeProviderBase<StateController<T>, StateController<T>>
+      notifier = AutoDisposeProvider((ref) => ref.watch(this));
+
   final Create<T, AutoDisposeProviderReference> _create;
 
   @override

--- a/packages/riverpod/lib/src/state_provider/base.dart
+++ b/packages/riverpod/lib/src/state_provider/base.dart
@@ -10,6 +10,9 @@ class StateProvider<T>
     String? name,
   }) : super(name);
 
+  late final AlwaysAliveProviderBase<StateController<T>, StateController<T>>
+      notifier = Provider((ref) => ref.watch(this));
+
   final Create<T, ProviderReference> _create;
 
   @override

--- a/packages/riverpod/lib/src/state_provider/base.dart
+++ b/packages/riverpod/lib/src/state_provider/base.dart
@@ -10,6 +10,27 @@ class StateProvider<T>
     String? name,
   }) : super(name);
 
+  /// {@template riverpod.stateprovider.notifier}
+  /// Obtains the [StateController] associated with this provider, but without
+  /// listening to it.
+  ///
+  /// Listening to this provider may cause providers/widgets to rebuild in the
+  /// event that the [StateController] it recreated.
+  ///
+  ///
+  /// It is preferrable to do:
+  /// ```dart
+  /// ref.watch(stateProvider.notifier)
+  /// ```
+  ///
+  /// instead of:
+  /// ```dart
+  /// ref.read(stateProvider)
+  /// ```
+  ///
+  /// The reasoning is, using `read` could cause hard to catch bugs, such as
+  /// not rebuilding dependent providers/widgets after using `context.refresh` on this provider.
+  /// {@endtemplate}
   late final AlwaysAliveProviderBase<StateController<T>, StateController<T>>
       notifier = Provider((ref) => ref.watch(this));
 

--- a/packages/riverpod/lib/src/state_provider/base.dart
+++ b/packages/riverpod/lib/src/state_provider/base.dart
@@ -6,9 +6,16 @@ class StateProvider<T>
     extends AlwaysAliveProviderBase<StateController<T>, StateController<T>> {
   /// {@macro riverpod.stateprovider}
   StateProvider(
-    Create<T, ProviderReference> create, {
+    this._create, {
     String? name,
-  }) : super((ref) => StateController(create(ref)), name);
+  }) : super(name);
+
+  final Create<T, ProviderReference> _create;
+
+  @override
+  StateController<T> create(ProviderReference ref) {
+    return StateController(_create(ref));
+  }
 
   /// {@macro riverpod.family}
   static const family = StateProviderFamilyBuilder();
@@ -55,7 +62,7 @@ extension StateFamilyX<T, Param> on Family<StateController<T>,
   ) {
     return FamilyOverride(
       this,
-      (dynamic param) {
+      (param) {
         return create(
           param as Param,
           (ref, a) => StateController(builderOverride(ref, a)),

--- a/packages/riverpod/lib/src/stream_provider.dart
+++ b/packages/riverpod/lib/src/stream_provider.dart
@@ -12,7 +12,6 @@ part 'stream_provider/auto_dispose.dart';
 part 'stream_provider/base.dart';
 
 mixin _StreamProviderMixin<T> on RootProvider<Stream<T>, AsyncValue<T>> {
-  @override
   Override overrideWithValue(AsyncValue<T> value) {
     return ProviderOverride(
       ValueProvider<Stream<T>, AsyncValue<T>>((ref) {

--- a/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
@@ -4,12 +4,16 @@ part of '../stream_provider.dart';
 @sealed
 class AutoDisposeStreamProvider<T>
     extends AutoDisposeProviderBase<Stream<T>, AsyncValue<T>>
-    with _StreamProviderMixin<T> {
+    with
+        ProviderOverridesMixin<Stream<T>, AsyncValue<T>>,
+        _StreamProviderMixin<T> {
   /// {@macro riverpod.streamprovider}
-  AutoDisposeStreamProvider(
-    Create<Stream<T>, AutoDisposeProviderReference> create, {
-    String? name,
-  }) : super(create, name);
+  AutoDisposeStreamProvider(this._create, {String? name}) : super(name);
+
+  final Create<Stream<T>, AutoDisposeProviderReference> _create;
+
+  @override
+  Stream<T> create(covariant AutoDisposeProviderReference ref) => _create(ref);
 
   /// {@macro riverpod.family}
   static const family = AutoDisposeStreamProviderFamilyBuilder();

--- a/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
@@ -5,7 +5,7 @@ part of '../stream_provider.dart';
 class AutoDisposeStreamProvider<T>
     extends AutoDisposeProviderBase<Stream<T>, AsyncValue<T>>
     with
-        ProviderOverridesMixin<Stream<T>, AsyncValue<T>>,
+        AutoDisposeProviderOverridesMixin<Stream<T>, AsyncValue<T>>,
         _StreamProviderMixin<T> {
   /// {@macro riverpod.streamprovider}
   AutoDisposeStreamProvider(this._create, {String? name}) : super(name);

--- a/packages/riverpod/lib/src/stream_provider/base.dart
+++ b/packages/riverpod/lib/src/stream_provider/base.dart
@@ -4,12 +4,16 @@ part of '../stream_provider.dart';
 @sealed
 class StreamProvider<T>
     extends AlwaysAliveProviderBase<Stream<T>, AsyncValue<T>>
-    with _StreamProviderMixin<T> {
+    with
+        ProviderOverridesMixin<Stream<T>, AsyncValue<T>>,
+        _StreamProviderMixin<T> {
   /// {@macro riverpod.streamprovider}
-  StreamProvider(
-    Create<Stream<T>, ProviderReference> create, {
-    String? name,
-  }) : super(create, name);
+  StreamProvider(this._create, {String? name}) : super(name);
+
+  final Create<Stream<T>, ProviderReference> _create;
+
+  @override
+  Stream<T> create(ProviderReference ref) => _create(ref);
 
   /// {@macro riverpod.family}
   static const family = StreamProviderFamilyBuilder();

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   mockito: ^5.0.0
   test: ^1.16.0
   # test_coverage: ^0.4.3
-  # trotter: ^1.2.0
+  trotter: ^2.0.0-dev.1

--- a/packages/riverpod/test/builders_test.dart
+++ b/packages/riverpod/test/builders_test.dart
@@ -107,8 +107,11 @@ void main() {
       StateNotifierProvider.family,
     );
     expect(
-      stateNotifierProviderBuilder((ref) => StateController(42), name: 'foo'),
-      isA<StateNotifierProvider<StateController<int>>>()
+      stateNotifierProviderBuilder<StateController<int>, int>(
+        (ref) => StateController(42),
+        name: 'foo',
+      ),
+      isA<StateNotifierProvider<StateController<int>, int>>()
           .having((s) => s.name, 'name', 'foo'),
     );
   });

--- a/packages/riverpod/test/family_test.dart
+++ b/packages/riverpod/test/family_test.dart
@@ -73,17 +73,18 @@ void main() {
   });
 
   test('Pass family and argument properties', () {
-    final family =
-        StateNotifierProvider.family<Counter, int>((_, a) => Counter());
+    final family = StateNotifierProvider.family<Counter, int, int>((_, a) {
+      return Counter();
+    });
     expect(
       family(0),
-      isA<StateNotifierProvider<Counter>>()
+      isA<StateNotifierProvider<Counter, int>>()
           .having((p) => p.argument, 'argument', 0)
           .having((p) => p.from, 'from', family),
     );
     expect(
       family(1),
-      isA<StateNotifierProvider<Counter>>()
+      isA<StateNotifierProvider<Counter, int>>()
           .having((p) => p.from, 'from', family)
           .having((p) => p.argument, 'argument', 1),
     );

--- a/packages/riverpod/test/framework2/framework_test.dart
+++ b/packages/riverpod/test/framework2/framework_test.dart
@@ -372,10 +372,10 @@ void main() {
     group('didChange', () {
       test('is called next sub.read', () {
         final counter = Counter();
-        final provider = StateNotifierProvider((ref) => counter);
+        final provider = StateNotifierProvider<Counter, int>((ref) => counter);
 
         final sub = container.listen(
-          provider.state,
+          provider,
           didChange: didChange,
         );
 
@@ -390,10 +390,10 @@ void main() {
 
       test('is called at most once per read', () {
         final counter = Counter();
-        final provider = StateNotifierProvider((ref) => counter);
+        final provider = StateNotifierProvider<Counter, int>((ref) => counter);
 
         final sub = container.listen(
-          provider.state,
+          provider,
           didChange: didChange,
         );
 
@@ -410,15 +410,15 @@ void main() {
 
       test('are all executed after one read call', () {
         final counter = Counter();
-        final provider = StateNotifierProvider((ref) => counter);
+        final provider = StateNotifierProvider<Counter, int>((ref) => counter);
         final didChange2 = DidChangedMock<int>();
 
         final sub = container.listen(
-          provider.state,
+          provider,
           didChange: didChange,
         );
         final sub2 = container.listen(
-          provider.state,
+          provider,
           didChange: didChange2,
         );
 
@@ -435,17 +435,17 @@ void main() {
 
       test('is guarded', () {
         final counter = Counter();
-        final provider = StateNotifierProvider((ref) => counter);
+        final provider = StateNotifierProvider<Counter, int>((ref) => counter);
         final didChange2 = DidChangedMock<int>();
         when(didChange(any)).thenThrow(42);
         when(didChange2(any)).thenThrow(21);
 
         final sub = container.listen(
-          provider.state,
+          provider,
           didChange: didChange,
         );
         final sub2 = container.listen(
-          provider.state,
+          provider,
           didChange: didChange2,
         );
 
@@ -463,8 +463,9 @@ void main() {
     group('mayHaveChanged', () {
       test('is optional', () {
         final counter = Counter();
-        final counterProvider = StateNotifierProvider((ref) => counter);
-        final provider = Provider((ref) => ref.watch(counterProvider.state));
+        final counterProvider =
+            StateNotifierProvider<Counter, int>((ref) => counter);
+        final provider = Provider((ref) => ref.watch(counterProvider));
 
         container.listen(provider);
 
@@ -476,11 +477,12 @@ void main() {
           'is synchronously after a change'
           ' without re-evaluating the provider', () {
         final counter = Counter();
-        final counterProvider = StateNotifierProvider((ref) => counter);
+        final counterProvider =
+            StateNotifierProvider<Counter, int>((ref) => counter);
         var callCount = 0;
         final provider = Provider((ref) {
           callCount++;
-          return ref.watch(counterProvider.state);
+          return ref.watch(counterProvider);
         });
 
         final sub = container.listen(provider, mayHaveChanged: mayHaveChanged);
@@ -498,9 +500,10 @@ void main() {
           're-evaluating the provider with a new value calls mayHaveChanged only once',
           () {
         final counter = Counter();
-        final counterProvider = StateNotifierProvider((ref) => counter);
+        final counterProvider =
+            StateNotifierProvider<Counter, int>((ref) => counter);
         final provider = Provider((ref) {
-          return ref.watch(counterProvider.state);
+          return ref.watch(counterProvider);
         });
 
         final sub = container.listen(provider, mayHaveChanged: mayHaveChanged);
@@ -513,9 +516,10 @@ void main() {
 
       test('is called only onces after multiple changes', () {
         final counter = Counter();
-        final counterProvider = StateNotifierProvider((ref) => counter);
+        final counterProvider =
+            StateNotifierProvider<Counter, int>((ref) => counter);
         final provider = Provider((ref) {
-          return ref.watch(counterProvider.state);
+          return ref.watch(counterProvider);
         });
 
         final sub = container.listen(provider, mayHaveChanged: mayHaveChanged);
@@ -539,17 +543,17 @@ void main() {
 
     test('is guarded', () {
       final counter = Counter();
-      final provider = StateNotifierProvider((ref) => counter);
+      final provider = StateNotifierProvider<Counter, int>((ref) => counter);
       final mayHaveChanged2 = MayHaveChangedMock<int>();
       when(mayHaveChanged(any)).thenThrow(42);
       when(mayHaveChanged2(any)).thenThrow(21);
 
       final sub = container.listen(
-        provider.state,
+        provider,
         mayHaveChanged: mayHaveChanged,
       );
       final sub2 = container.listen(
-        provider.state,
+        provider,
         mayHaveChanged: mayHaveChanged2,
       );
 
@@ -565,8 +569,8 @@ void main() {
   group('ProviderSubscription', () {
     test('no-longer call listeners anymore after close', () {
       final counter = Counter();
-      final first = StateNotifierProvider((ref) => counter);
-      final provider = Provider((ref) => ref.watch(first.state));
+      final first = StateNotifierProvider<Counter, int>((ref) => counter);
+      final provider = Provider((ref) => ref.watch(first));
       final element = container.readProviderElement(provider);
 
       expect(element.hasListeners, false);
@@ -614,8 +618,8 @@ void main() {
 
       test('flushes the provider', () {
         final counter = Counter();
-        final first = StateNotifierProvider((ref) => counter);
-        final provider = Provider((ref) => ref.watch(first.state));
+        final first = StateNotifierProvider<Counter, int>((ref) => counter);
+        final provider = Provider((ref) => ref.watch(first));
 
         final sub = container.listen(provider);
 
@@ -646,9 +650,9 @@ void main() {
 
       test('updates to true after a change', () {
         final counter = Counter();
-        final provider = StateNotifierProvider((ref) => counter);
+        final provider = StateNotifierProvider<Counter, int>((ref) => counter);
 
-        final sub = container.listen(provider.state);
+        final sub = container.listen(provider);
 
         sub.read();
 
@@ -659,11 +663,11 @@ void main() {
 
       test('flushes providers', () {
         final counter = Counter();
-        final first = StateNotifierProvider((ref) => counter);
+        final first = StateNotifierProvider<Counter, int>((ref) => counter);
         var callCount = 0;
         final provider = Provider((ref) {
           callCount++;
-          return ref.watch(first.state);
+          return ref.watch(first);
         });
 
         expect(callCount, 0);

--- a/packages/riverpod/test/framework2/provider_test.dart
+++ b/packages/riverpod/test/framework2/provider_test.dart
@@ -8,11 +8,10 @@ void main() {
   setUp(() => container = ProviderContainer());
   tearDown(() => container.dispose());
 
-  test('Provider.autoDispose can be overriden by anything', () {
+  test('Provider.autoDispose can be overriden by auto-dispose providers', () {
     final provider = Provider.autoDispose((_) => 42);
-    final RootProvider<Object?, int> override = Provider((_) {
-      return 21;
-    });
+    final AutoDisposeProviderBase<Object?, int> override =
+        Provider.autoDispose((_) => 21);
     final container = ProviderContainer(overrides: [
       provider.overrideWithProvider(override),
     ]);
@@ -24,7 +23,7 @@ void main() {
 
   test('Provider can be overriden by anything', () {
     final provider = Provider((_) => 42);
-    final RootProvider<Object?, int> override = Provider((_) {
+    final AlwaysAliveProviderBase<Object?, int> override = Provider((_) {
       return 21;
     });
     final container = ProviderContainer(overrides: [

--- a/packages/riverpod/test/framework2/provider_test.dart
+++ b/packages/riverpod/test/framework2/provider_test.dart
@@ -53,9 +53,9 @@ void main() {
 
   test("rebuild don't notify clients if == doesn't change", () {
     final counter = Counter();
-    final other = StateNotifierProvider((ref) => counter);
+    final other = StateNotifierProvider<Counter, int>((ref) => counter);
     final provider = Provider((ref) {
-      return ref.watch(other.state).isEven;
+      return ref.watch(other).isEven;
     });
 
     final sub = container.listen(provider);
@@ -71,9 +71,9 @@ void main() {
 
   test('rebuild notify clients if == did change', () {
     final counter = Counter();
-    final other = StateNotifierProvider((ref) => counter);
+    final other = StateNotifierProvider<Counter, int>((ref) => counter);
     final provider = Provider((ref) {
-      return ref.watch(other.state).isEven;
+      return ref.watch(other).isEven;
     });
 
     final sub = container.listen(provider);

--- a/packages/riverpod/test/framework2/state_provider_test.dart
+++ b/packages/riverpod/test/framework2/state_provider_test.dart
@@ -10,7 +10,75 @@ void main() {
     container.dispose();
   });
 
+  group('StateProvider', () {
+    test('.notifier obtains the controller without listening to it', () {
+      final dep = StateProvider((ref) => 0);
+      final provider = StateProvider((ref) {
+        ref.watch(dep);
+        return 0;
+      });
+
+      var callCount = 0;
+      final sub = container.listen(
+        provider.notifier,
+        didChange: (_) => callCount++,
+      );
+
+      final controller = container.read(provider);
+
+      expect(sub.read(), controller);
+      expect(callCount, 0);
+
+      controller.state++;
+
+      sub.flush();
+      expect(callCount, 0);
+
+      container.read(dep).state++;
+
+      final controller2 = container.read(provider);
+      expect(controller2, isNot(controller));
+
+      sub.flush();
+      expect(sub.read(), controller2);
+      expect(callCount, 1);
+    });
+  });
+
   group('StateProvider.autoDispose', () {
+    test('.notifier obtains the controller without listening to it', () {
+      final dep = StateProvider((ref) => 0);
+      final provider = StateProvider.autoDispose((ref) {
+        ref.watch(dep);
+        return 0;
+      });
+
+      var callCount = 0;
+      final sub = container.listen(
+        provider.notifier,
+        didChange: (_) => callCount++,
+      );
+
+      final controller = container.read(provider);
+
+      expect(sub.read(), controller);
+      expect(callCount, 0);
+
+      controller.state++;
+
+      sub.flush();
+      expect(callCount, 0);
+
+      container.read(dep).state++;
+
+      final controller2 = container.read(provider);
+      expect(controller2, isNot(controller));
+
+      sub.flush();
+      expect(sub.read(), controller2);
+      expect(callCount, 1);
+    });
+
     test('creates a new controller when no-longer listened', () async {
       final provider = StateProvider.autoDispose((ref) => 0);
 

--- a/packages/riverpod/test/framework2/stream_provider_test.dart
+++ b/packages/riverpod/test/framework2/stream_provider_test.dart
@@ -51,7 +51,7 @@ void main() {
       )).thenReturn(subMock);
 
       final container = ProviderContainer(overrides: [
-        provider.stream.overrideWithValue(streamMock),
+        provider.overrideWithProvider(StreamProvider((ref) => streamMock)),
       ]);
 
       final last = container.read(provider.last);
@@ -83,7 +83,7 @@ void main() {
       )).thenReturn(subMock);
 
       final container = ProviderContainer(overrides: [
-        provider.stream.overrideWithValue(streamMock),
+        provider.overrideWithProvider(StreamProvider((ref) => streamMock)),
       ]);
 
       final last = container.read(provider.last);
@@ -104,6 +104,10 @@ void main() {
         ),
       );
 
+      verifyZeroInteractions(subMock);
+
+      container.dispose();
+
       verify(subMock.cancel()).called(1);
     });
 
@@ -120,7 +124,7 @@ void main() {
       )).thenReturn(subMock);
 
       final container = ProviderContainer(overrides: [
-        provider.stream.overrideWithValue(streamMock),
+        provider.overrideWithProvider(StreamProvider((ref) => streamMock)),
       ]);
 
       final last = container.read(provider.last);
@@ -139,6 +143,10 @@ void main() {
       // TODO(rrousselGit) test that the stacktrace is preserved
       await expectLater(last, throwsA(error));
 
+      verifyZeroInteractions(subMock);
+
+      container.dispose();
+
       verify(subMock.cancel()).called(1);
     });
 
@@ -155,7 +163,7 @@ void main() {
       )).thenReturn(subMock);
 
       final container = ProviderContainer(overrides: [
-        provider.stream.overrideWithValue(streamMock),
+        provider.overrideWithProvider(StreamProvider((ref) => streamMock)),
       ]);
 
       final last = container.read(provider.last);
@@ -169,6 +177,10 @@ void main() {
       onValue(42);
 
       await expectLater(last, completion(42));
+
+      verifyZeroInteractions(subMock);
+
+      container.dispose();
 
       verify(subMock.cancel()).called(1);
     });

--- a/packages/riverpod/test/framework_test.dart
+++ b/packages/riverpod/test/framework_test.dart
@@ -368,6 +368,13 @@ void main() {
     });
   });
 
+  test('disposing an already disposed container is no-op', () {
+    final container = ProviderContainer();
+
+    container.dispose();
+    container.dispose();
+  });
+
   test('cannot call markMayHaveChanged after dispose', () {
     final container = ProviderContainer();
     final provider = Provider((ref) {});

--- a/packages/riverpod/test/framework_test.dart
+++ b/packages/riverpod/test/framework_test.dart
@@ -146,14 +146,14 @@ void main() {
 
   test('guard listeners', () {
     final notifier = Counter();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Counter, int>((_) => notifier);
     final container = ProviderContainer();
     final listener = ListenerMock();
     final listener2 = ListenerMock();
 
     final firstErrors = <Object>[];
     runZonedGuarded(
-      () => provider.state.watchOwner(container, (value) {
+      () => provider.watchOwner(container, (value) {
         listener(value);
         // ignore: only_throw_errors
         throw value;
@@ -165,7 +165,7 @@ void main() {
     verifyNoMoreInteractions(listener);
     expect(firstErrors, [0]);
 
-    provider.state.watchOwner(container, listener2);
+    provider.watchOwner(container, listener2);
 
     verify(listener2(0)).called(1);
     verifyNoMoreInteractions(listener2);
@@ -188,12 +188,12 @@ void main() {
 
   test('reading unflushed triggers flush', () {
     final notifier = Counter();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Counter, int>((_) => notifier);
     final container = ProviderContainer();
     var callCount = 0;
     final computed = Provider((ref) {
       callCount++;
-      return ref.watch(provider.state);
+      return ref.watch(provider);
     });
     final listener = ListenerMock();
     final listener2 = ListenerMock();
@@ -235,12 +235,12 @@ void main() {
 
   test('flusing closed subscription throws', () {
     final notifier = Counter();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Counter, int>((_) => notifier);
     final container = ProviderContainer();
     final listener = ListenerMock();
     final mayHaveChanged = MockMarkMayHaveChanged();
 
-    final sub = provider.state.addLazyListener(
+    final sub = provider.addLazyListener(
       container,
       mayHaveChanged: mayHaveChanged,
       onChange: listener,
@@ -260,12 +260,12 @@ void main() {
 
   test('reading closed subscription is throws', () {
     final notifier = Counter();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Counter, int>((_) => notifier);
     final container = ProviderContainer();
     final listener = ListenerMock();
     final mayHaveChanged = MockMarkMayHaveChanged();
 
-    final sub = provider.state.addLazyListener(
+    final sub = provider.addLazyListener(
       container,
       mayHaveChanged: mayHaveChanged,
       onChange: listener,
@@ -339,7 +339,7 @@ void main() {
   test('container.debugProviderValues', () {
     final unnamed = Provider((_) => 0);
     final counter = Counter();
-    final named = StateNotifierProvider((_) {
+    final named = StateNotifierProvider<Counter, int>((_) {
       return counter;
     }, name: 'named');
     final container = ProviderContainer();
@@ -352,19 +352,19 @@ void main() {
       unnamed: 0,
     });
 
-    expect(container.read(named), counter);
+    expect(container.read(named.notifier), counter);
 
     expect(container.debugProviderValues, {
       unnamed: 0,
-      named: counter,
+      named.notifier: counter,
     });
 
-    expect(container.read(named.state), 0);
+    expect(container.read(named), 0);
 
     expect(container.debugProviderValues, {
       unnamed: 0,
-      named: counter,
-      named.state: 0,
+      named.notifier: counter,
+      named: 0,
     });
   });
 
@@ -570,12 +570,12 @@ void main() {
   group('notify listeners', () {
     test('calls onChange at most once per flush', () {
       final counter = Counter();
-      final provider = StateNotifierProvider<Counter>((_) => counter);
+      final provider = StateNotifierProvider<Counter, int>((_) => counter);
       final container = ProviderContainer();
       final mayHaveChanged = MockMarkMayHaveChanged();
       final listener = ListenerMock();
 
-      final sub = provider.state.addLazyListener(
+      final sub = provider.addLazyListener(
         container,
         mayHaveChanged: mayHaveChanged,
         onChange: listener,
@@ -616,12 +616,12 @@ void main() {
 
     test('noop if no provider was "dirty"', () {
       final counter = Counter();
-      final provider = StateNotifierProvider<Counter>((_) => counter);
+      final provider = StateNotifierProvider<Counter, int>((_) => counter);
       final container = ProviderContainer();
       final mayHaveChanged = MockMarkMayHaveChanged();
       final listener = ListenerMock();
 
-      final sub = provider.state.addLazyListener(
+      final sub = provider.addLazyListener(
         container,
         mayHaveChanged: mayHaveChanged,
         onChange: listener,
@@ -650,11 +650,11 @@ void main() {
     test('on update`', () async {
       final container = ProviderContainer();
       final counter = Counter();
-      final provider = StateNotifierProvider<Counter>((_) => counter);
+      final provider = StateNotifierProvider<Counter, int>((_) => counter);
       final mayHaveChanged = MockMarkMayHaveChanged();
       final listener = ListenerMock();
 
-      final sub = provider.state.addLazyListener(
+      final sub = provider.addLazyListener(
         container,
         mayHaveChanged: mayHaveChanged,
         onChange: listener,
@@ -681,19 +681,24 @@ void main() {
       final counter2 = Counter();
       final counter3 = Counter();
 
-      final provider = StateNotifierProvider<Counter>((_) => counter);
-      final provider2 = StateNotifierProvider<Counter>((ref) {
-        ref.watch(provider);
+      final sprovider = StateNotifierProvider<Counter, int>((_) => counter);
+      final sprovider2 = StateNotifierProvider<Counter, int>((ref) {
+        ref.watch(sprovider);
         return counter2;
       });
-      final provider3 = StateNotifierProvider<Counter>((ref) {
-        ref.watch(provider2);
+      final sprovider3 = StateNotifierProvider<Counter, int>((ref) {
+        ref.watch(sprovider2);
         return counter3;
       });
 
+      // using Provider because StateNotifierProvider synchronously calls its listeners
+      final provider = Provider<int>((ref) => ref.watch(sprovider));
+      final provider2 = Provider<int>((ref) => ref.watch(sprovider2));
+      final provider3 = Provider<int>((ref) => ref.watch(sprovider3));
+
       final mayHaveChanged = MockMarkMayHaveChanged();
       final listener = ListenerMock('first');
-      final sub = provider.state.addLazyListener(
+      final sub = provider.addLazyListener(
         container,
         mayHaveChanged: mayHaveChanged,
         onChange: listener,
@@ -701,7 +706,7 @@ void main() {
 
       final mayHaveChanged2 = MockMarkMayHaveChanged();
       final listener2 = ListenerMock('second');
-      final sub2 = provider2.state.addLazyListener(
+      final sub2 = provider2.addLazyListener(
         container,
         mayHaveChanged: mayHaveChanged2,
         onChange: listener2,
@@ -709,7 +714,7 @@ void main() {
 
       final mayHaveChanged3 = MockMarkMayHaveChanged();
       final listener3 = ListenerMock('third');
-      final sub3 = provider3.state.addLazyListener(
+      final sub3 = provider3.addLazyListener(
         container,
         mayHaveChanged: mayHaveChanged3,
         onChange: listener3,

--- a/packages/riverpod/test/provider/auto_dispose_state_notifier_provider_test.dart
+++ b/packages/riverpod/test/provider/auto_dispose_state_notifier_provider_test.dart
@@ -170,7 +170,7 @@ void main() {
     final notifier = TestNotifier(42);
     final notifier2 = TestNotifier(21);
     final container = ProviderContainer(overrides: [
-      provider.overrideWitProvider(
+      provider.overrideWithProvider(
         StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
           return notifier;
         }),
@@ -194,7 +194,7 @@ void main() {
     verifyOnly(listener, listener(43));
 
     container.updateOverrides([
-      provider.overrideWitProvider(
+      provider.overrideWithProvider(
         StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
           return notifier2;
         }),

--- a/packages/riverpod/test/provider/auto_dispose_state_notifier_provider_test.dart
+++ b/packages/riverpod/test/provider/auto_dispose_state_notifier_provider_test.dart
@@ -2,15 +2,13 @@ import 'package:mockito/mockito.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:test/test.dart';
 
-import 'package:riverpod/src/internals.dart' as internals;
-
 import '../utils.dart';
 
 void main() {
   test('StateNotifierFamily override', () async {
     final notifier2 = TestNotifier(42);
     final provider = StateNotifierProvider.autoDispose
-        .family<TestNotifier, int>((ref, a) => TestNotifier());
+        .family<TestNotifier, int, int>((ref, a) => TestNotifier());
     final container = ProviderContainer(
       overrides: [provider.overrideWithProvider((ref, a) => notifier2)],
     );
@@ -20,12 +18,12 @@ void main() {
     // access in the child container
     // try to read provider.state before provider and see if it points to the override
     final ownerStateRemove =
-        provider(0).state.watchOwner(container, ownerStateListener);
+        provider(0).watchOwner(container, ownerStateListener);
     verify(ownerStateListener(42)).called(1);
     verifyNoMoreInteractions(ownerStateListener);
 
     final ownerNotifierRemove =
-        provider(0).watchOwner(container, ownerNotifierListener);
+        provider(0).notifier.watchOwner(container, ownerNotifierListener);
     verify(ownerNotifierListener(notifier2)).called(1);
     verifyNoMoreInteractions(ownerNotifierListener);
 
@@ -43,22 +41,14 @@ void main() {
     expect(notifier2.mounted, false);
   });
 
-  test('can be assigned to Provider.autoDispose', () {
-    // ignore: unused_local_variable
-    final internals.AutoDisposeProvider<TestNotifier> provider =
-        StateNotifierProvider.autoDispose((_) {
+  test('overriding the provider overrides provider.state too', () {
+    final provider = StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
       return TestNotifier();
     });
-  });
-
-  test('overriding the provider overrides provider.state too', () {
-    final provider = StateNotifierProvider.autoDispose((_) => TestNotifier());
     final notifier = TestNotifier(42);
     final container = ProviderContainer(
       overrides: [
-        provider.overrideWithProvider(
-          StateNotifierProvider.autoDispose((_) => TestNotifier(10)),
-        )
+        provider.overrideWithValue(TestNotifier(10)),
       ],
     );
     final stateListener = Listener<int>();
@@ -66,15 +56,14 @@ void main() {
 
     // does not crash
     container.updateOverrides([
-      provider.overrideWithProvider(
-          StateNotifierProvider.autoDispose((_) => notifier)),
+      provider.overrideWithValue(notifier),
     ]);
 
-    provider.watchOwner(container, notifierListener);
+    provider.notifier.watchOwner(container, notifierListener);
     verify(notifierListener(notifier)).called(1);
     verifyNoMoreInteractions(notifierListener);
 
-    provider.state.watchOwner(container, stateListener);
+    provider.watchOwner(container, stateListener);
     verify(stateListener(42)).called(1);
     verifyNoMoreInteractions(stateListener);
 
@@ -91,18 +80,18 @@ void main() {
       name: 'example',
     );
 
+    expect(provider.notifier.name, 'example.notifier');
     expect(provider.name, 'example');
-    expect(provider.state.name, 'example.state');
 
     final provider2 = StateNotifierProvider.autoDispose((_) => TestNotifier());
 
+    expect(provider2.notifier.name, isNull);
     expect(provider2.name, isNull);
-    expect(provider2.state.name, isNull);
   });
 
   test('disposes the notifier when provider is unmounted', () {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider.autoDispose<TestNotifier>((_) {
+    final provider = StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
       return notifier;
     });
     final container = ProviderContainer();
@@ -117,13 +106,13 @@ void main() {
 
   test('provider subscribe the callback is never', () async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider.autoDispose<TestNotifier>((_) {
+    final provider = StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
       return notifier;
     });
     final listener = ControllerListenerMock();
     final container = ProviderContainer();
 
-    final sub = provider.addLazyListener(
+    final sub = provider.notifier.addLazyListener(
       container,
       mayHaveChanged: () {},
       onChange: listener,
@@ -147,13 +136,13 @@ void main() {
 
   test('provider subscribe callback never called', () async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider.autoDispose<TestNotifier>((_) {
+    final provider = StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
       return notifier;
     });
     final listener = Listener<int>();
     final container = ProviderContainer();
 
-    final sub = provider.state.addLazyListener(
+    final sub = provider.addLazyListener(
       container,
       mayHaveChanged: () {},
       onChange: listener,

--- a/packages/riverpod/test/provider/auto_dispose_state_notifier_provider_test.dart
+++ b/packages/riverpod/test/provider/auto_dispose_state_notifier_provider_test.dart
@@ -163,6 +163,40 @@ void main() {
     verifyNoMoreInteractions(listener);
   });
 
+  test('.notifier obtains the controller without listening to it', () {
+    final dep = StateProvider((ref) => 0);
+    final notifier = TestNotifier();
+    final notifier2 = TestNotifier();
+    final provider =
+        StateNotifierProvider.autoDispose<TestNotifier, int>((ref) {
+      return ref.watch(dep).state == 0 ? notifier : notifier2;
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    var callCount = 0;
+    final sub = container.listen(
+      provider.notifier,
+      didChange: (_) => callCount++,
+    );
+
+    expect(sub.read(), notifier);
+    expect(callCount, 0);
+
+    notifier.increment();
+
+    sub.flush();
+    expect(callCount, 0);
+
+    container.read(dep).state++;
+
+    expect(sub.read(), notifier2);
+
+    sub.flush();
+    expect(sub.read(), notifier2);
+    expect(callCount, 1);
+  });
+
   test('overrideWithProvider preserves the state accross update', () {
     final provider = StateNotifierProvider.autoDispose<TestNotifier, int>((_) {
       return TestNotifier();

--- a/packages/riverpod/test/provider/state_notifier_provider_test.dart
+++ b/packages/riverpod/test/provider/state_notifier_provider_test.dart
@@ -190,7 +190,7 @@ void main() {
     final notifier = TestNotifier(42);
     final notifier2 = TestNotifier(21);
     final container = ProviderContainer(overrides: [
-      provider.overrideWitProvider(
+      provider.overrideWithProvider(
         StateNotifierProvider<TestNotifier, int>((_) {
           return notifier;
         }),
@@ -214,7 +214,7 @@ void main() {
     verifyOnly(listener, listener(43));
 
     container.updateOverrides([
-      provider.overrideWitProvider(
+      provider.overrideWithProvider(
         StateNotifierProvider<TestNotifier, int>((_) {
           return notifier2;
         }),

--- a/packages/riverpod/test/provider/state_notifier_provider_test.dart
+++ b/packages/riverpod/test/provider/state_notifier_provider_test.dart
@@ -6,74 +6,69 @@ import '../utils.dart';
 
 void main() {
   test('StateNotifierFamily override', () {
-    final provider = StateNotifierProvider.family<TestNotifier, int>(
-        (ref, a) => TestNotifier());
-    final notifier2 = TestNotifier(42);
-    final container = ProviderContainer(
-      overrides: [provider.overrideWithProvider((ref, a) => notifier2)],
-    );
-
-    // access in the child container
-    // try to read provider.state before provider and see if it points to the override
-    expect(container.read(provider(0).state), 42);
-    expect(container.read(provider(0)), notifier2);
-  });
-
-  test('can be assigned to provider', () {
-    final Provider<TestNotifier> provider = StateNotifierProvider((_) {
+    final provider =
+        StateNotifierProvider.family<TestNotifier, int, int>((ref, a) {
       return TestNotifier();
     });
-    final container = ProviderContainer();
+    final notifier2 = TestNotifier(42);
+    final container = ProviderContainer(
+      overrides: [
+        provider.overrideWithProvider((ref, a) => notifier2),
+      ],
+    );
 
-    expect(container.read(provider), isA<TestNotifier>());
+    expect(container.read(provider(0).notifier), notifier2);
+    // access in the child container
+    // try to read provider.state before provider and see if it points to the override
+    expect(container.read(provider(0)), 42);
   });
 
   test('overriding the provider overrides provider.state too', () {
     final notifier = TestNotifier(42);
-    final provider = StateNotifierProvider((_) => TestNotifier());
+    final provider =
+        StateNotifierProvider<TestNotifier, int>((_) => TestNotifier());
     final container = ProviderContainer(
       overrides: [
-        provider.overrideWithProvider(
-            StateNotifierProvider((_) => TestNotifier(10)))
+        provider.overrideWithValue(TestNotifier(10)),
       ],
     );
 
     // does not crash
     container.updateOverrides([
-      provider.overrideWithProvider(StateNotifierProvider((_) => notifier)),
+      provider.overrideWithValue(notifier),
     ]);
 
-    expect(container.read(provider), notifier);
-    expect(container.read(provider.state), 42);
+    expect(container.read(provider.notifier), notifier);
+    expect(container.read(provider), 42);
 
     notifier.increment();
 
-    expect(container.read(provider.state), 43);
+    expect(container.read(provider), 43);
   });
 
   test('can specify name', () {
-    final provider = StateNotifierProvider(
-      (_) => TestNotifier(),
-      name: 'example',
-    );
+    final provider = StateNotifierProvider<TestNotifier, int>((_) {
+      return TestNotifier();
+    }, name: 'example');
 
+    expect(provider.notifier.name, 'example.notifier');
     expect(provider.name, 'example');
-    expect(provider.state.name, 'example.state');
 
-    final provider2 = StateNotifierProvider((_) => TestNotifier());
+    final provider2 =
+        StateNotifierProvider<TestNotifier, int>((_) => TestNotifier());
 
+    expect(provider2.notifier.name, isNull);
     expect(provider2.name, isNull);
-    expect(provider2.state.name, isNull);
   });
 
   test('disposes the notifier when provider is unmounted', () {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider<TestNotifier>((_) {
+    final provider = StateNotifierProvider<TestNotifier, int>((_) {
       return notifier;
     });
     final container = ProviderContainer();
 
-    expect(container.read(provider), notifier);
+    expect(container.read(provider.notifier), notifier);
     expect(notifier.mounted, isTrue);
 
     container.dispose();
@@ -83,13 +78,13 @@ void main() {
 
   test('provider subscribe the callback is never', () async {
     final notifier = TestNotifier();
-    final provider = StateNotifierProvider<TestNotifier>((_) {
+    final provider = StateNotifierProvider<TestNotifier, int>((_) {
       return notifier;
     });
     final listener = ControllerListenerMock();
     final container = ProviderContainer();
 
-    final sub = provider.addLazyListener(
+    final sub = provider.notifier.addLazyListener(
       container,
       mayHaveChanged: () {},
       onChange: listener,
@@ -112,13 +107,13 @@ void main() {
   });
 
   test('provider subscribe callback never called', () async {
-    final provider = StateNotifierProvider<TestNotifier>((_) {
+    final provider = StateNotifierProvider<TestNotifier, int>((_) {
       return TestNotifier();
     });
     final listener = ListenerMock();
     final container = ProviderContainer();
 
-    final sub = provider.state.addLazyListener(
+    final sub = provider.addLazyListener(
       container,
       mayHaveChanged: () {},
       onChange: listener,
@@ -127,7 +122,7 @@ void main() {
     verify(listener(0)).called(1);
     verifyNoMoreInteractions(listener);
 
-    container.read(provider).increment();
+    container.read(provider.notifier).increment();
 
     verifyNoMoreInteractions(listener);
     sub.read();
@@ -145,6 +140,11 @@ class TestNotifier extends StateNotifier<int> {
   TestNotifier([int initialValue = 0]) : super(initialValue);
 
   void increment() => state++;
+
+  @override
+  String toString() {
+    return 'TestNotifier($state)';
+  }
 }
 
 class ListenerMock extends Mock {

--- a/packages/riverpod/test/ref_watch_test.dart
+++ b/packages/riverpod/test/ref_watch_test.dart
@@ -23,28 +23,31 @@ void main() {
     final stateProvider = StateProvider((ref) => 0, name: 'state');
     final notifier0 = Counter();
     final notifier1 = Counter(42);
-    final provider0 = StateNotifierProvider((_) => notifier0, name: '0');
-    final provider1 = StateNotifierProvider((_) => notifier1, name: '1');
+    final provider0 = StateNotifierProvider<Counter, int>((_) {
+      return notifier0;
+    }, name: '0');
+    final provider1 = StateNotifierProvider<Counter, int>((_) {
+      return notifier1;
+    }, name: '1');
     var buildCount = 0;
     final computed = Provider((ref) {
       buildCount++;
 
       final state = ref.watch(stateProvider).state;
-      final value =
-          state == 0 ? ref.watch(provider0.state) : ref.watch(provider1.state);
+      final value = state == 0 ? ref.watch(provider0) : ref.watch(provider1);
 
-      return '${ref.watch(provider0.state)} $value';
+      return '${ref.watch(provider0)} $value';
     });
     final listener = Listener<String>();
     final container = ProviderContainer();
 
-    container.read(provider0.state);
-    container.read(provider1.state);
+    container.read(provider0);
+    container.read(provider1);
     final familyState0 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider0.state;
+      return p.provider == provider0;
     });
     final familyState1 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider1.state;
+      return p.provider == provider1;
     });
 
     computed.watchOwner(container, listener);
@@ -93,26 +96,28 @@ void main() {
     final stateProvider = StateProvider((ref) => 0, name: 'state');
     final notifier0 = Counter();
     final notifier1 = Counter(42);
-    final provider0 = StateNotifierProvider((_) => notifier0, name: '0');
-    final provider1 = StateNotifierProvider((_) => notifier1, name: '1');
+    final provider0 = StateNotifierProvider<Counter, int>((_) {
+      return notifier0;
+    }, name: '0');
+    final provider1 = StateNotifierProvider<Counter, int>((_) {
+      return notifier1;
+    }, name: '1');
     var buildCount = 0;
     final computed = Provider((ref) {
       buildCount++;
       final state = ref.watch(stateProvider).state;
-      return state == 0
-          ? ref.watch(provider0.state)
-          : ref.watch(provider1.state);
+      return state == 0 ? ref.watch(provider0) : ref.watch(provider1);
     });
     final listener = Listener<int>();
     final container = ProviderContainer();
 
-    container.read(provider0.state);
-    container.read(provider1.state);
+    container.read(provider0);
+    container.read(provider1);
     final familyState0 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider0.state;
+      return p.provider == provider0;
     });
     final familyState1 = container.debugProviderElements.firstWhere((p) {
-      return p.provider == provider1.state;
+      return p.provider == provider1;
     });
 
     computed.watchOwner(container, listener);
@@ -162,11 +167,13 @@ void main() {
       return ref.watch(provider).toString();
     });
     final notifier = Counter();
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Counter, int>((_) {
+      return notifier;
+    });
     final container = ProviderContainer();
     final listener = Listener<String>();
 
-    computed(provider.state).watchOwner(container, listener);
+    computed(provider).watchOwner(container, listener);
 
     verify(listener('0')).called(1);
     verifyNoMoreInteractions(listener);
@@ -182,15 +189,17 @@ void main() {
       () {
     final container = ProviderContainer();
     final notifier = Notifier(0);
-    final provider = StateNotifierProvider((_) => notifier);
+    final provider = StateNotifierProvider<Notifier<int>, int>((_) {
+      return notifier;
+    });
     var callCount = 0;
     final computed = Provider((ref) {
       callCount++;
-      return ref.watch(provider.state);
+      return ref.watch(provider);
     });
 
     final tested = Provider((ref) {
-      final first = ref.watch(provider.state);
+      final first = ref.watch(provider);
       final second = ref.watch(computed);
       return '$first $second';
     });
@@ -269,8 +278,10 @@ void main() {
 
   test('disposing the Provider closes subscriptions', () {
     final notifier = Notifier(0);
-    final provider = StateNotifierProvider<Notifier<int>>((_) => notifier);
-    final computed = Provider((ref) => ref.watch(provider.state));
+    final provider = StateNotifierProvider<Notifier<int>, int>((_) {
+      return notifier;
+    });
+    final computed = Provider((ref) => ref.watch(provider));
     final container = ProviderContainer();
     final mayHaveChanged = MockMarkMayHaveChanged();
     final listener = Listener<int>();
@@ -294,11 +305,13 @@ void main() {
   test('can call ref.watch outside of the Provider', () async {
     final container = ProviderContainer();
     final notifier = Notifier(0);
-    final provider = StateNotifierProvider<Notifier<int>>((_) => notifier);
+    final provider = StateNotifierProvider<Notifier<int>, int>((_) {
+      return notifier;
+    });
     var callCount = 0;
     final computed = StreamProvider((ref) async* {
       callCount++;
-      yield ref.watch(provider.state);
+      yield ref.watch(provider);
     });
 
     final sub = container.listen(computed);
@@ -321,11 +334,13 @@ void main() {
   test('the value is cached between multiple listeners', () {
     final container = ProviderContainer();
     final notifier = Notifier(0);
-    final provider = StateNotifierProvider<Notifier<int>>((_) => notifier);
+    final provider = StateNotifierProvider<Notifier<int>, int>((_) {
+      return notifier;
+    });
     var callCount = 0;
     final computed = Provider((ref) {
       callCount++;
-      return [ref.watch(provider.state)];
+      return [ref.watch(provider)];
     });
 
     late List<int> first;
@@ -356,13 +371,15 @@ void main() {
   test('Simple Provider flow', () {
     final container = ProviderContainer();
     final notifier = Notifier(0);
-    final provider = StateNotifierProvider<Notifier<int>>((_) => notifier);
+    final provider = StateNotifierProvider<Notifier<int>, int>((_) {
+      return notifier;
+    });
     final mayHaveChanged = MockMarkMayHaveChanged();
     final listener = Listener<bool>();
     var callCount = 0;
     final isPositiveComputed = Provider((ref) {
       callCount++;
-      return !ref.watch(provider.state).isNegative;
+      return !ref.watch(provider).isNegative;
     });
 
     final sub = isPositiveComputed.addLazyListener(

--- a/packages/riverpod/test/uni_directional_test.dart
+++ b/packages/riverpod/test/uni_directional_test.dart
@@ -186,7 +186,7 @@ void main() {
   test("initState can't dirty siblings", () {
     final ancestor = StateProvider((_) => 0, name: 'ancestor');
     final counter = Counter();
-    final sibling = StateNotifierProvider((ref) {
+    final sibling = StateNotifierProvider<Counter, int>((ref) {
       ref.watch(ancestor).state;
       return counter;
     }, name: 'sibling');
@@ -197,7 +197,7 @@ void main() {
       counter.increment();
     }, name: 'child');
 
-    container.read(sibling.state);
+    container.read(sibling);
 
     expect(errorsOf(() => container.read(child)), isNotEmpty);
     expect(didWatchAncestor, true);
@@ -217,7 +217,7 @@ void main() {
 
   test("nested initState can't mark dirty other providers", () {
     final counter = Counter();
-    final provider = StateNotifierProvider((_) => counter);
+    final provider = StateNotifierProvider<Counter, int>((_) => counter);
     final nested = Provider((_) => 0);
     final provider2 = Provider((ref) {
       ref.watch(nested);
@@ -225,14 +225,14 @@ void main() {
       return 0;
     });
 
-    expect(container.read(provider.state), 0);
+    expect(container.read(provider), 0);
 
     expect(errorsOf(() => container.read(provider2)), isNotEmpty);
   });
 
   test('auto dispose can dirty providers', () async {
     final counter = Counter();
-    final provider = StateNotifierProvider((_) => counter);
+    final provider = StateNotifierProvider<Counter, int>((_) => counter);
     var didDispose = false;
     final provider2 = Provider.autoDispose((ref) {
       ref.onDispose(() {
@@ -241,7 +241,7 @@ void main() {
       });
     });
 
-    container.read(provider.state);
+    container.read(provider);
 
     final sub = container.listen(provider2);
     sub.close();
@@ -256,7 +256,7 @@ void main() {
 
   test("Provider can't dirty anything on create", () {
     final counter = Counter();
-    final provider = StateNotifierProvider((_) => counter);
+    final provider = StateNotifierProvider<Counter, int>((_) => counter);
     late List<Object> errors;
     final computed = Provider((ref) {
       errors = errorsOf(counter.increment);
@@ -264,7 +264,7 @@ void main() {
     });
     final listener = Listener();
 
-    expect(container.read(provider.state), 0);
+    expect(container.read(provider), 0);
 
     computed.watchOwner(container, listener);
 

--- a/packages/riverpod/test/utils.dart
+++ b/packages/riverpod/test/utils.dart
@@ -95,8 +95,8 @@ class _EqualsIgnoringHashCodes extends Matcher {
   }
 
   @override
-  bool matches(dynamic object, Map<dynamic, dynamic> matchState) {
-    final description = _normalize(object as String);
+  bool matches(Object? object, Map<Object?, Object?> matchState) {
+    final description = _normalize(object! as String);
     if (_value != description) {
       matchState[_mismatchedValueKey] = description;
       return false;
@@ -111,13 +111,13 @@ class _EqualsIgnoringHashCodes extends Matcher {
 
   @override
   Description describeMismatch(
-    dynamic item,
+    Object? item,
     Description mismatchDescription,
-    Map<dynamic, dynamic> matchState,
+    Map<Object?, Object?> matchState,
     bool verbose,
   ) {
     if (matchState.containsKey(_mismatchedValueKey)) {
-      final actualValue = matchState[_mismatchedValueKey] as String;
+      final actualValue = matchState[_mismatchedValueKey]! as String;
       // Leading whitespace is added so that lines in the multiline
       // description returned by addDescriptionOf are all indented equally
       // which makes the output easier to read for this case.
@@ -133,28 +133,29 @@ class _EqualsIgnoringHashCodes extends Matcher {
 
 class ObserverMock extends Mock implements ProviderObserver {
   @override
-  void didDisposeProvider(ProviderBase? provider) {
+  void didDisposeProvider(ProviderBase<Object?, Object?>? provider) {
     super.noSuchMethod(
       Invocation.method(#didDisposeProvider, [provider]),
     );
   }
 
   @override
-  void didAddProvider(ProviderBase? provider, Object? value) {
+  void didAddProvider(ProviderBase<Object?, Object?>? provider, Object? value) {
     super.noSuchMethod(
       Invocation.method(#didAddProvider, [provider, value]),
     );
   }
 
   @override
-  void didUpdateProvider(ProviderBase? provider, Object? newValue) {
+  void didUpdateProvider(
+      ProviderBase<Object?, Object?>? provider, Object? newValue) {
     super.noSuchMethod(
       Invocation.method(#didUpdateProvider, [provider, newValue]),
     );
   }
 
   @override
-  void mayHaveChanged(ProviderBase? provider) {
+  void mayHaveChanged(ProviderBase<Object?, Object?>? provider) {
     super.noSuchMethod(
       Invocation.method(#mayHaveChanged, [provider]),
     );

--- a/packages/riverpod/test/visit_states_test.dart
+++ b/packages/riverpod/test/visit_states_test.dart
@@ -1,297 +1,297 @@
 import 'package:riverpod/src/internals.dart';
-// import 'package:test/test.dart';
-// import 'package:trotter/trotter.dart';
+import 'package:test/test.dart';
+import 'package:trotter/trotter.dart';
 
 void main() {
-  // //  A
-  // //  |
-  // //  B
-  // //  |
-  // //  C
-  // test('linear graph', () {
-  //   final a = Provider<A>((ref) => A());
+  //  A
+  //  |
+  //  B
+  //  |
+  //  C
+  test('linear graph', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = Provider<B>((ref) {
-  //     ref.watch(a);
-  //     return B();
-  //   });
-  //   final c = Provider<C>((ref) {
-  //     ref.watch(b);
-  //     return C();
-  //   });
+    final b = Provider<B>((ref) {
+      ref.watch(a);
+      return B();
+    });
+    final c = Provider<C>((ref) {
+      ref.watch(b);
+      return C();
+    });
 
-  //   final perm = Permutations(3, [a, b, c]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer();
-  //     permutation.forEach(container.read);
-  //     expect(compute(container), [a, b, c]);
-  //   }
-  // });
-  // //     A
-  // //   /   \
-  // //  B     C
-  // //    \  /
-  // //      D
-  // test('diamond graph', () {
-  //   final a = Provider<A>((ref) => A());
+    final perm = Permutations(3, [a, b, c]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer();
+      permutation.forEach(container.read);
+      expect(compute(container), [a, b, c]);
+    }
+  });
+  //     A
+  //   /   \
+  //  B     C
+  //    \  /
+  //      D
+  test('diamond graph', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = Provider<B>((ref) {
-  //     ref.watch(a);
-  //     return B();
-  //   });
-  //   final c = Provider<C>((ref) {
-  //     ref.watch(a);
-  //     return C();
-  //   });
+    final b = Provider<B>((ref) {
+      ref.watch(a);
+      return B();
+    });
+    final c = Provider<C>((ref) {
+      ref.watch(a);
+      return C();
+    });
 
-  //   final d = Provider<D>((ref) {
-  //     ref.watch(b);
-  //     ref.watch(c);
-  //     return D();
-  //   });
+    final d = Provider<D>((ref) {
+      ref.watch(b);
+      ref.watch(c);
+      return D();
+    });
 
-  //   final perm = Permutations(4, [a, b, c, d]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer();
-  //     permutation.forEach(container.read);
-  //     expect(
-  //       compute(container),
-  //       anyOf([
-  //         [a, b, c, d],
-  //         [a, c, b, d],
-  //       ]),
-  //     );
-  //   }
-  // });
+    final perm = Permutations(4, [a, b, c, d]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer();
+      permutation.forEach(container.read);
+      expect(
+        compute(container),
+        anyOf([
+          [a, b, c, d],
+          [a, c, b, d],
+        ]),
+      );
+    }
+  });
 
-  // //  A#1
-  // //  |
-  // //  B#2
-  // test('linear across two containers', () {
-  //   final a = Provider<A>((ref) => A());
+  //  A#1
+  //  |
+  //  B#2
+  test('linear across two containers', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = ScopedProvider<B>((watch) {
-  //     watch(a);
-  //     return B();
-  //   });
+    final b = ScopedProvider<B>((watch) {
+      watch(a);
+      return B();
+    });
 
-  //   final parent = ProviderContainer();
-  //   final container = ProviderContainer(parent: parent);
-  //   container.read(b);
+    final parent = ProviderContainer();
+    final container = ProviderContainer(parent: parent);
+    container.read(b);
 
-  //   expect(compute(container), [b]);
-  // });
+    expect(compute(container), [b]);
+  });
 
-  // //  A#1  B#2
-  // //    \  /
-  // //     C#2
-  // test('branching across two containers', () {
-  //   final a = Provider<A>((ref) => A());
+  //  A#1  B#2
+  //    \  /
+  //     C#2
+  test('branching across two containers', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = ScopedProvider<B>((watch) {
-  //     return B();
-  //   });
+    final b = ScopedProvider<B>((watch) {
+      return B();
+    });
 
-  //   final c = ScopedProvider<C>((watch) {
-  //     watch(a);
-  //     watch(b);
-  //     return C();
-  //   });
+    final c = ScopedProvider<C>((watch) {
+      watch(a);
+      watch(b);
+      return C();
+    });
 
-  //   final parent = ProviderContainer();
+    final parent = ProviderContainer();
 
-  //   final perm = Permutations(2, [b, c]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer(parent: parent);
-  //     permutation.forEach(container.read);
+    final perm = Permutations(2, [b, c]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer(parent: parent);
+      permutation.forEach(container.read);
 
-  //     expect(compute(container), [b, c]);
-  //   }
-  // });
+      expect(compute(container), [b, c]);
+    }
+  });
 
-  // ///       A
-  // ///     /   \
-  // ///    B __  |
-  // ///    |   | |
-  // ///    E   |-C
-  // ///   / \    |
-  // ///  D   F__/|
-  // ///      \   |
-  // ///       G_/
+  ///       A
+  ///     /   \
+  ///    B __  |
+  ///    |   | |
+  ///    E   |-C
+  ///   / \    |
+  ///  D   F__/|
+  ///      \   |
+  ///       G_/
 
-  // //       A
-  // //     /   \
-  // //    B  <  C
-  // //   / \    / \
-  // //  D > E <F < G
-  // test('5', () {
-  //   final a = Provider<A>((ref) => A());
+  //       A
+  //     /   \
+  //    B  <  C
+  //   / \    / \
+  //  D > E <F < G
+  test('5', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = Provider<B>((ref) {
-  //     ref.watch(a);
-  //     return B();
-  //   });
+    final b = Provider<B>((ref) {
+      ref.watch(a);
+      return B();
+    });
 
-  //   final e = Provider<E>((ref) {
-  //     ref.watch(b);
-  //     return E();
-  //   });
-  //   final d = Provider<D>((ref) {
-  //     ref.watch(b);
-  //     ref.watch(e);
-  //     return D();
-  //   });
+    final e = Provider<E>((ref) {
+      ref.watch(b);
+      return E();
+    });
+    final d = Provider<D>((ref) {
+      ref.watch(b);
+      ref.watch(e);
+      return D();
+    });
 
-  //   final c = Provider<C>((ref) {
-  //     ref.watch(a);
-  //     ref.watch(b);
-  //     return C();
-  //   });
+    final c = Provider<C>((ref) {
+      ref.watch(a);
+      ref.watch(b);
+      return C();
+    });
 
-  //   final f = Provider<F>((ref) {
-  //     ref.watch(c);
-  //     ref.watch(e);
-  //     return F();
-  //   });
-  //   final g = Provider<G>((ref) {
-  //     ref.watch(c);
-  //     ref.watch(f);
-  //     return G();
-  //   });
+    final f = Provider<F>((ref) {
+      ref.watch(c);
+      ref.watch(e);
+      return F();
+    });
+    final g = Provider<G>((ref) {
+      ref.watch(c);
+      ref.watch(f);
+      return G();
+    });
 
-  //   final perm = Permutations(7, [a, b, c, d, e, f, g]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer();
-  //     permutation.forEach(container.read);
-  //     expect(
-  //       compute(container),
-  //       anyOf([
-  //         [a, b, c, e, d, f, g],
-  //         [a, b, c, e, f, g, d],
-  //         [a, b, c, e, f, d, g],
-  //         [a, b, e, c, d, f, g],
-  //         [a, b, e, c, f, g, d],
-  //         [a, b, e, c, f, d, g],
-  //         [a, b, e, d, c, f, g],
-  //       ]),
-  //     );
-  //   }
-  // });
-  // //     A
-  // //   /  |
-  // //  B   |
-  // //  | \ |
-  // //  |   C
-  // //   \ /
-  // //    D
-  // test('linked diamond graph', () {
-  //   final a = Provider<A>((ref) => A());
+    final perm = Permutations(7, [a, b, c, d, e, f, g]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer();
+      permutation.forEach(container.read);
+      expect(
+        compute(container),
+        anyOf([
+          [a, b, c, e, d, f, g],
+          [a, b, c, e, f, g, d],
+          [a, b, c, e, f, d, g],
+          [a, b, e, c, d, f, g],
+          [a, b, e, c, f, g, d],
+          [a, b, e, c, f, d, g],
+          [a, b, e, d, c, f, g],
+        ]),
+      );
+    }
+  });
+  //     A
+  //   /  |
+  //  B   |
+  //  | \ |
+  //  |   C
+  //   \ /
+  //    D
+  test('linked diamond graph', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = Provider<B>((ref) {
-  //     ref.watch(a);
-  //     return B();
-  //   });
-  //   final c = Provider<C>((ref) {
-  //     ref.watch(a);
-  //     ref.watch(b);
-  //     return C();
-  //   });
+    final b = Provider<B>((ref) {
+      ref.watch(a);
+      return B();
+    });
+    final c = Provider<C>((ref) {
+      ref.watch(a);
+      ref.watch(b);
+      return C();
+    });
 
-  //   final d = Provider<D>((ref) {
-  //     ref.watch(b);
-  //     ref.watch(c);
-  //     return D();
-  //   });
+    final d = Provider<D>((ref) {
+      ref.watch(b);
+      ref.watch(c);
+      return D();
+    });
 
-  //   final perm = Permutations(4, [a, b, c, d]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer();
-  //     permutation.forEach(container.read);
-  //     expect(
-  //       compute(container),
-  //       [a, b, c, d],
-  //     );
-  //   }
-  // });
-  // //  A
-  // //  |
-  // //  B
-  // //  | \
-  // //  |  C
-  // //  | /
-  // //   D
-  // test('graph4', () {
-  //   final a = Provider<A>((ref) => A());
+    final perm = Permutations(4, [a, b, c, d]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer();
+      permutation.forEach(container.read);
+      expect(
+        compute(container),
+        [a, b, c, d],
+      );
+    }
+  });
+  //  A
+  //  |
+  //  B
+  //  | \
+  //  |  C
+  //  | /
+  //   D
+  test('graph4', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = Provider<B>((ref) {
-  //     ref.watch(a);
-  //     return B();
-  //   });
-  //   final c = Provider<C>((ref) {
-  //     ref.watch(b);
-  //     return C();
-  //   });
+    final b = Provider<B>((ref) {
+      ref.watch(a);
+      return B();
+    });
+    final c = Provider<C>((ref) {
+      ref.watch(b);
+      return C();
+    });
 
-  //   final d = Provider<D>((ref) {
-  //     ref.watch(b);
-  //     ref.watch(c);
-  //     return D();
-  //   });
+    final d = Provider<D>((ref) {
+      ref.watch(b);
+      ref.watch(c);
+      return D();
+    });
 
-  //   final perm = Permutations(4, [a, b, c, d]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer();
-  //     permutation.forEach(container.read);
-  //     expect(
-  //       compute(container),
-  //       [a, b, c, d],
-  //     );
-  //   }
-  // });
-  // //     A
-  // //   /   \
-  // //  B     C
-  // //  |     |
-  // //  D     |
-  // //   \   /
-  // //     E
-  // test('graph6', () {
-  //   final a = Provider<A>((ref) => A());
+    final perm = Permutations(4, [a, b, c, d]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer();
+      permutation.forEach(container.read);
+      expect(
+        compute(container),
+        [a, b, c, d],
+      );
+    }
+  });
+  //     A
+  //   /   \
+  //  B     C
+  //  |     |
+  //  D     |
+  //   \   /
+  //     E
+  test('graph6', () {
+    final a = Provider<A>((ref) => A());
 
-  //   final b = Provider<B>((ref) {
-  //     ref.watch(a);
-  //     return B();
-  //   });
-  //   final c = Provider<C>((ref) {
-  //     ref.watch(a);
-  //     return C();
-  //   });
+    final b = Provider<B>((ref) {
+      ref.watch(a);
+      return B();
+    });
+    final c = Provider<C>((ref) {
+      ref.watch(a);
+      return C();
+    });
 
-  //   final d = Provider<D>((ref) {
-  //     ref.watch(b);
-  //     return D();
-  //   });
+    final d = Provider<D>((ref) {
+      ref.watch(b);
+      return D();
+    });
 
-  //   final e = Provider<E>((ref) {
-  //     ref.watch(d);
-  //     ref.watch(c);
-  //     return E();
-  //   });
+    final e = Provider<E>((ref) {
+      ref.watch(d);
+      ref.watch(c);
+      return E();
+    });
 
-  //   final perm = Permutations(5, [a, b, c, d, e]);
-  //   for (final permutation in perm()) {
-  //     final container = ProviderContainer();
-  //     permutation.forEach(container.read);
-  //     expect(
-  //       compute(container),
-  //       anyOf([
-  //         [a, b, d, c, e],
-  //         [a, b, c, d, e],
-  //         [a, c, b, d, e],
-  //       ]),
-  //     );
-  //   }
-  // });
+    final perm = Permutations(5, [a, b, c, d, e]);
+    for (final permutation in perm()) {
+      final container = ProviderContainer();
+      permutation.forEach(container.read);
+      expect(
+        compute(container),
+        anyOf([
+          [a, b, d, c, e],
+          [a, b, c, d, e],
+          [a, c, b, d, e],
+        ]),
+      );
+    }
+  });
 }
 
 List<ProviderBase> compute(ProviderContainer container) {

--- a/tools/generate_providers/bin/generate_providers.dart
+++ b/tools/generate_providers/bin/generate_providers.dart
@@ -24,14 +24,21 @@ enum StateType {
   stream,
 }
 
-const stateLabel = {
-  StateType.none: '',
-  StateType.state: 'State',
-  StateType.stateNotifier: 'StateNotifier',
-  StateType.changeNotifier: 'ChangeNotifier',
-  StateType.future: 'Future',
-  StateType.stream: 'Stream',
-};
+class StateDetails {
+  StateDetails({
+    this.kind,
+    this.className,
+    this.constraints,
+    this.generics,
+    this.createType,
+  });
+
+  final StateType kind;
+  final String className;
+  final String constraints;
+  final String generics;
+  final String createType;
+}
 
 enum ProviderType {
   single,
@@ -39,8 +46,8 @@ enum ProviderType {
 }
 
 const providerLabel = {
-  ProviderType.single: 'Provider',
-  ProviderType.family: 'ProviderFamily',
+  ProviderType.single: '',
+  ProviderType.family: 'Family',
 };
 
 const _autoDisposeDoc = '''
@@ -342,20 +349,61 @@ Future<void> main(List<String> args) async {
     return;
   }
 
-  Tuple3<List<DisposeType>, List<StateType>, List<ProviderType>> matrix;
+  Tuple3<List<DisposeType>, List<StateDetails>, List<ProviderType>> matrix;
 
-  final builder = StringBuffer();
+  final builder = StringBuffer('''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+//
+// If you need to modify this file, instead update /tools/generate_providers/bin/generate_providers.dart
+//
+// You can install this utility by executing:
+// dart pub global activate -s path <repository_path>/tools/generate_providers
+//
+// You can then use it in your terminal by executing:
+// generate_providers <riverpod/flutter_riverpod/hooks_riverpod> <path to builder file to update>
+
+''');
 
   switch (args.first) {
     case 'riverpod':
-      matrix = const Tuple3(
+      matrix = Tuple3(
         DisposeType.values,
         [
-          StateType.state,
-          StateType.stateNotifier,
-          StateType.none,
-          StateType.future,
-          StateType.stream,
+          StateDetails(
+            kind: StateType.state,
+            className: 'StateProvider',
+            constraints: 'T',
+            generics: 'T',
+            createType: 'T',
+          ),
+          StateDetails(
+            kind: StateType.stateNotifier,
+            className: 'StateNotifierProvider',
+            constraints: 'Notifier extends StateNotifier<Value>, Value',
+            generics: 'Notifier, Value',
+            createType: 'Notifier',
+          ),
+          StateDetails(
+            kind: StateType.none,
+            className: 'Provider',
+            constraints: 'T',
+            generics: 'T',
+            createType: 'T',
+          ),
+          StateDetails(
+            kind: StateType.future,
+            className: 'FutureProvider',
+            constraints: 'T',
+            generics: 'T',
+            createType: 'Future<T>',
+          ),
+          StateDetails(
+            kind: StateType.stream,
+            className: 'StreamProvider',
+            constraints: 'T',
+            generics: 'T',
+            createType: 'Stream<T>',
+          ),
         ],
         ProviderType.values,
       );
@@ -368,9 +416,17 @@ import 'internals.dart';
       );
       break;
     case 'flutter_riverpod':
-      matrix = const Tuple3(
+      matrix = Tuple3(
         DisposeType.values,
-        [StateType.changeNotifier],
+        [
+          StateDetails(
+            kind: StateType.changeNotifier,
+            className: 'ChangeNotifierProvider',
+            constraints: 'Notifier extends ChangeNotifier',
+            generics: 'Notifier',
+            createType: 'Notifier',
+          ),
+        ],
         ProviderType.values,
       );
       builder.writeln(
@@ -392,7 +448,7 @@ import 'internals.dart';
 }
 
 Iterable<Object> generateAll(
-  Tuple3<List<DisposeType>, List<StateType>, List<ProviderType>> matrix,
+  Tuple3<List<DisposeType>, List<StateDetails>, List<ProviderType>> matrix,
 ) sync* {
   final combos = Combinations(3, <Object>[
     ...matrix.item1,
@@ -404,15 +460,17 @@ Iterable<Object> generateAll(
     final second = permutation[1];
     final third = permutation[2];
 
-    if (first is DisposeType && second is StateType && third is ProviderType) {
+    if (first is DisposeType &&
+        second is StateDetails &&
+        third is ProviderType) {
       yield* generate(Tuple3(first, second, third), matrix);
     }
   }
 }
 
-extension on Tuple3<DisposeType, StateType, ProviderType> {
+extension on Tuple3<DisposeType, StateDetails, ProviderType> {
   String get providerName {
-    return '${disposeLabel[item1]}${stateLabel[item2]}${providerLabel[item3]}';
+    return '${disposeLabel[item1]}${item2.className}${providerLabel[item3]}';
   }
 
   String get ref {
@@ -425,30 +483,12 @@ extension on Tuple3<DisposeType, StateType, ProviderType> {
     }
   }
 
-  String get constraint {
-    switch (item2) {
-      case StateType.stateNotifier:
-        return ' extends StateNotifier<Object?>';
-      case StateType.changeNotifier:
-        return ' extends ChangeNotifier';
-      default:
-        return '';
-    }
-  }
+  String get constraint => item2.constraints;
 
-  String get createType {
-    switch (item2) {
-      case StateType.future:
-        return 'Future<T>';
-      case StateType.stream:
-        return 'Stream<T>';
-      default:
-        return 'T';
-    }
-  }
+  String get createType => item2.createType;
 
   String links(
-    Tuple3<List<DisposeType>, List<StateType>, List<ProviderType>> matrix,
+    Tuple3<List<DisposeType>, List<StateDetails>, List<ProviderType>> matrix,
   ) {
     Iterable<String> other() sync* {
       if (item1 == DisposeType.none) {
@@ -475,8 +515,8 @@ ${familyDoc().replaceAll('///', '  ///')}
 }
 
 Iterable<Object> generate(
-  Tuple3<DisposeType, StateType, ProviderType> configs,
-  Tuple3<List<DisposeType>, List<StateType>, List<ProviderType>> matrix,
+  Tuple3<DisposeType, StateDetails, ProviderType> configs,
+  Tuple3<List<DisposeType>, List<StateDetails>, List<ProviderType>> matrix,
 ) sync* {
   if (configs.item3 == ProviderType.family) {
     yield FamilyBuilder(configs, matrix);
@@ -487,8 +527,9 @@ Iterable<Object> generate(
 
 class FamilyBuilder {
   FamilyBuilder(this.configs, this.matrix);
-  final Tuple3<DisposeType, StateType, ProviderType> configs;
-  final Tuple3<List<DisposeType>, List<StateType>, List<ProviderType>> matrix;
+  final Tuple3<DisposeType, StateDetails, ProviderType> configs;
+  final Tuple3<List<DisposeType>, List<StateDetails>, List<ProviderType>>
+      matrix;
 
   @override
   String toString() {
@@ -499,8 +540,8 @@ class ${configs.providerName}Builder {
   const ${configs.providerName}Builder();
 
 ${familyDoc().replaceAll('///', '  ///')}
-  ${configs.providerName}<T, Value> call<T${configs.constraint}, Value>(
-    ${configs.createType} Function(${configs.ref} ref, Value value) create, {
+  ${configs.providerName}<${configs.item2.generics}, Param> call<${configs.constraint}, Param>(
+    ${configs.createType} Function(${configs.ref} ref, Param param) create, {
     String? name,
   }) {
     return ${configs.providerName}(create, name: name);
@@ -513,8 +554,9 @@ ${configs.links(matrix)}
 
 class ProviderBuilder {
   ProviderBuilder(this.configs, this.matrix);
-  final Tuple3<DisposeType, StateType, ProviderType> configs;
-  final Tuple3<List<DisposeType>, List<StateType>, List<ProviderType>> matrix;
+  final Tuple3<DisposeType, StateDetails, ProviderType> configs;
+  final Tuple3<List<DisposeType>, List<StateDetails>, List<ProviderType>>
+      matrix;
 
   @override
   String toString() {
@@ -525,7 +567,7 @@ class ${configs.providerName}Builder {
   const ${configs.providerName}Builder();
 
 ${autoDisposeDoc().replaceAll('///', '  ///')}
-  ${configs.providerName}<T> call<T${configs.constraint}>(
+  ${configs.providerName}<${configs.item2.generics}> call<${configs.constraint}>(
     ${configs.createType} Function(${configs.ref} ref) create, {
     String? name,
   }) {

--- a/website/docs/concepts/combining_providers.mdx
+++ b/website/docs/concepts/combining_providers.mdx
@@ -80,7 +80,7 @@ An easy way to implement such scenario would be to:
   ```dart
   final filteredTodoListProvider = Provider<List<Todo>>((ref) {
     final filter = ref.watch(filterProvider);
-    final todos = ref.watch(todoListProvider.state);
+    final todos = ref.watch(todoListProvider);
 
     switch (filter.state) {
       case Filter.none:


### PR DESCRIPTION
This updates the syntax of StateNotifierProvider/StateProvider/ChangeNotifierProvider as per #341

closes #341

Remaning tasks:

- [x] overrideWithProvider on autoDispose does not compile if provider passed is not autoDispose
- [x] add StateNotifierProvider.overrideWithProvider
- [x] add ChangeNotifierProvider.notifier
- [x] add StateProvider.notifier
- [x] fix https://github.com/rrousselGit/river_pod/issues/370
- [x] update the doc
- [x] add dartdoc for the new ".notifier"