### PR TITLE
Fix combining provider doc example that had await on an AsyncValue

### DIFF
--- a/website/docs/concepts/combining_providers.mdx
+++ b/website/docs/concepts/combining_providers.mdx
@@ -252,14 +252,15 @@ final productsProvider = FutureProvider<List<Product>>((ref) async {
 final configsProvider = StreamProvider<Configuration>(...);
 
 /// A provider that exposes only the current host
-final _hostProvider = Provider<AsyncValue<String>>((ref) {
-  return ref.watch(configsProvider).whenData((configs) => configs.host);
+final _hostProvider = FutureProvider<String>((ref) async {
+  final config = await ref.watch(configsProvider.last);
+  return config.host;
 });
 
 final productsProvider = FutureProvider<List<Product>>((ref) async {
   // Listens only to the host. If something else in the configurations
   // changes, this will not pointlessly re-evaluate our provider.
-  final host = await ref.watch(_hostProvider);
+  final host = await ref.watch(_hostProvider.future);
 
   return dio.get('$host/products');
 });


### PR DESCRIPTION
Fixes https://github.com/rrousselGit/river_pod/issues/411

Upon further review, I can't say with certainty that this is the way it should be written. It sort of depends on the situation. In [this StackOverflow answer](https://stackoverflow.com/a/66955043/7259858), the second approach may be more correct for that case.