### PR TITLE
Marvel Example: Override dioProvider instead of repositoryProvider

### DIFF
--- a/examples/marvel/lib/main.dart
+++ b/examples/marvel/lib/main.dart
@@ -18,11 +18,7 @@ void main() {
       // uncomment to mock the HTTP requests
 
       // overrides: [
-      //   repositoryProvider.overrideWithProvider(
-      //     Provider(
-      //       (ref) => MarvelRepository(ref, client: FakeDio(null)),
-      //     ),
-      //   ),
+      //   dioProvider.overrideWithValue(FakeDio(null))
       // ],
       child: MyApp(),
     ),


### PR DESCRIPTION
Fixes https://github.com/rrousselGit/river_pod/issues/438