### PR TITLE
update dependencies for hooks_riverpod

### DIFF
--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.1
+
+Bump `flutter_hooks` version
+
 # 0.14.0+3
 
 Removed an assert that could cause issues when an application is partially migrated to null safety.

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -2,19 +2,19 @@ name: hooks_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and testable.
-version: 0.14.0+3
+version: 0.14.1
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.16.0
+  flutter_hooks: ^0.17.0
   flutter_riverpod: ^0.14.0+3
   riverpod: ^0.14.0+3
   state_notifier: ^0.7.0


### PR DESCRIPTION
```log
Running "flutter pub get" in my_project...                    

Because hooks_riverpod 0.14.0+3 depends on flutter_hooks ^0.16.0 and no versions of hooks_riverpod match >0.14.0+3 <0.15.0, hooks_riverpod ^0.14.0+3 requires flutter_hooks ^0.16.0.
So, because my_project depends on both flutter_hooks ^0.17.0 and hooks_riverpod ^0.14.0+3, version solving failed.
pub get failed (1; So, because my_project depends on both flutter_hooks ^0.17.0 and hooks_riverpod ^0.14.0+3, version solving failed.)
Process finished with exit code 1
```