### PR TITLE
Fixing improper cache deletion (2)

### DIFF
--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -215,9 +215,6 @@ class ProviderContainer {
       'Removed a key that does not exist',
     );
     _stateReaders.remove(element._origin);
-    if (element._origin.from != null) {
-      element._origin.from!._cache.remove(element._origin.argument);
-    }
     element.dispose();
   }
 

--- a/packages/riverpod/lib/src/framework/family.dart
+++ b/packages/riverpod/lib/src/framework/family.dart
@@ -23,7 +23,12 @@ abstract class Family<Created, Listened, Param, Ref extends ProviderReference,
   P call(Param value) {
     return _cache.putIfAbsent(value, () {
       final provider =
-          create(value, builder, name == null ? null : '$name ($value)');
+      create(value, (ref, value) {
+        ref.onDispose(() {
+          _cache.remove(value);
+        });
+        return builder(ref, value);
+      }, name == null ? null : '$name ($value)');
       assert(
         provider._from == null,
         'The provider created already belongs to a Family',


### PR DESCRIPTION
Thank you for comment last time. I corrected the previous point.

Write about issue #456.

When AutoDisposeStateNotifierProvider is created, _AutoDisposeNotifierProvider is created by ref.watch(notifier).
However, when the ProviderElement for AutoDisposeStateNotifierProvider is disposed, the provider is also removed from the Family._cache even though the ProviderElement for _AutoDisposeNotifierProvider is using it.
Therefore, the timing to remove from Family._cache was changed to the timing to dispose the ProviderElement that created by the Provider.