### PR TITLE
Update 'Installing the package' for flutter_hooks to 0.17

### DIFF
--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -63,7 +63,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.17.0-nullsafety.0
+  flutter_hooks: ^0.17.0
   hooks_riverpod: ^0.14.0+4
 ```
 

--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -63,7 +63,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.16.0-nullsafety.0
+  flutter_hooks: ^0.17.0-nullsafety.0
   hooks_riverpod: ^0.14.0+4
 ```
 


### PR DESCRIPTION
Just a small update from  flutter_hooks to 0.16 to flutter_hooks to 0.17
I received the following `flutter pub get` error when running the getting started example code for flutter_hooks.

```
[getting_started] flutter pub get
Running "flutter pub get" in getting_started...                  
Because hooks_riverpod >=0.14.0+4 depends on flutter_hooks ^0.17.0 and getting_started depends on flutter_hooks ^0.16.0-nullsafety.0, hooks_riverpod >=0.14.0+4 is forbidden.
So, because getting_started depends on hooks_riverpod ^0.14.0+4, version solving failed.

pub get failed (1; So, because getting_started depends on hooks_riverpod ^0.14.0+4, version solving failed.)
```

