### PR TITLE
revert changes to riverpod_cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           channel: ${{ matrix.channel }}
 
-      - name: 'skip riverpod_cli'
-        run: rm -rf packages/riverpod_cli
-
       - name: Add pub cache bin to PATH
         run: echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
 

--- a/packages/riverpod_cli/fixtures/notifiers/golden/change_notifier_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/change_notifier_provider.dart
@@ -31,25 +31,25 @@ class ConsumerWatch extends ConsumerWidget {
   const ConsumerWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(counterProvider);
+  Widget build(BuildContext context, ScopedReader watch) {
+    final count = watch(counterProvider);
     return Center(
       child: Text('$count'),
     );
   }
 }
 
-class HooksWatch extends HookConsumerWidget {
+class HooksWatch extends HookWidget {
   const HooksWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     // ignore: unused_local_variable
-    final countNotifier = ref.watch(counterProvider);
+    final countNotifier = useProvider(counterProvider);
     return Center(
       child: ElevatedButton(
         onPressed: () {
-          ref.read(counterProvider);
+          context.read(counterProvider);
         },
         child: const Text('Press Me'),
       ),

--- a/packages/riverpod_cli/fixtures/notifiers/golden/pubspec.yaml
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/pubspec.yaml
@@ -9,6 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter  
-  flutter_riverpod: ^1.0.0-dev.0
-  hooks_riverpod: ^1.0.0-dev.0
-  riverpod: ^1.0.0-dev.0
+  flutter_riverpod: ^0.14.0
+  hooks_riverpod: ^0.14.0
+  riverpod: ^0.14.0

--- a/packages/riverpod_cli/fixtures/notifiers/golden/state_notifier_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/state_notifier_provider.dart
@@ -40,34 +40,34 @@ class ConsumerWatch extends ConsumerWidget {
   const ConsumerWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context, ScopedReader watch) {
     // ignore: unused_local_variable
-    final countNotifier = ref.watch(counterProvider.notifier);
-    final count = ref.watch(counterProvider);
+    final countNotifier = watch(counterProvider.notifier);
+    final count = watch(counterProvider);
     return Center(
       child: Text('$count'),
     );
   }
 }
 
-class HooksWatch extends HookConsumerWidget {
+class HooksWatch extends HookWidget {
   const HooksWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     // ignore: unused_local_variable
-    final countNotifier = ref.watch(counterProvider.notifier);
+    final countNotifier = useProvider(counterProvider.notifier);
     // ignore: unused_local_variable
-    final count = ref.watch(counterProvider);
+    final count = useProvider(counterProvider);
     return Center(
       child: ElevatedButton(
         onPressed: () {
-          ref.read(counterProvider.notifier);
-          ref.read(counterProvider);
-          ref.read(Counter.counterStaticProvider);
-          ref.read(Counter.counterStaticProvider.notifier);
-          ref.read(Counter.familyStaticProvider(''));
-          ref.read(Counter.familyStaticProvider('').notifier);
+          context.read(counterProvider.notifier);
+          context.read(counterProvider);
+          context.read(Counter.counterStaticProvider);
+          context.read(Counter.counterStaticProvider.notifier);
+          context.read(Counter.familyStaticProvider(''));
+          context.read(Counter.familyStaticProvider('').notifier);
         },
         child: const Text('Press Me'),
       ),

--- a/packages/riverpod_cli/fixtures/notifiers/golden/state_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/state_provider.dart
@@ -18,30 +18,30 @@ class ConsumerWatch extends ConsumerWidget {
   const ConsumerWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context, ScopedReader watch) {
     // ignore: unused_local_variable
-    final countNotifier = ref.watch(counterProvider);
-    final count = ref.watch(counterProvider).state;
+    final countNotifier = watch(counterProvider);
+    final count = watch(counterProvider).state;
     return Center(
       child: Text('$count'),
     );
   }
 }
 
-class HooksWatch extends HookConsumerWidget {
+class HooksWatch extends HookWidget {
   const HooksWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     // ignore: unused_local_variable
-    final countNotifier = ref.watch(counterProvider);
+    final countNotifier = useProvider(counterProvider);
     // ignore: unused_local_variable
-    final count = ref.watch(counterProvider).state;
+    final count = useProvider(counterProvider).state;
     return Center(
       child: ElevatedButton(
         onPressed: () {
-          ref.read(counterProvider);
-          ref.read(counterProvider).state;
+          context.read(counterProvider);
+          context.read(counterProvider).state;
         },
         child: const Text('Press Me'),
       ),

--- a/packages/riverpod_cli/lib/src/migrate/notifiers.dart
+++ b/packages/riverpod_cli/lib/src/migrate/notifiers.dart
@@ -75,7 +75,7 @@ class RiverpodNotifierChangesMigrationSuggestor
     // ref.watch(provider.state) => ref.watch(provider)
     // ref.read(provider.state) => ref.read(provider)
     // context.read(provider.state) => context.read(provider)
-    // ref.watch(provider.state) => ref.watch(provider)
+    // useProvider(provider.state) => useProvider(provider)
     if (node.identifier.name == 'state') {
       if (node.prefix.staticType
           .getDisplayString()
@@ -103,13 +103,13 @@ class RiverpodNotifierChangesMigrationSuggestor
   void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
     if (node.function.toSource() == 'read' ||
         node.function.toSource() == 'watch' ||
-        node.function.toSource() == 'ref.watch(') {
+        node.function.toSource() == 'useProvider') {
       final firstArgStaticType =
           node.argumentList.arguments.first.staticType.getDisplayString();
       if (firstArgStaticType.contains('StateNotifierProvider')) {
         // StateNotifierProvider
         // watch(provider) => watch(provider.notifier)
-        // ref.watch(provider) => ref.watch(provider.notifier)
+        // useProvider(provider) => ref.watch(provider.notifier)
         yieldPatch('.notifier', node.argumentList.arguments.first.end,
             node.argumentList.arguments.first.end);
       }
@@ -119,10 +119,10 @@ class RiverpodNotifierChangesMigrationSuggestor
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    // ref.read / ref.watch / context.read / context.watch, ref.watch(
+    // ref.read / ref.watch / context.read / context.watch, useProvider
     if (node.methodName.toSource() == 'read' ||
         node.methodName.toSource() == 'watch' ||
-        node.methodName.toSource() == 'ref.watch(') {
+        node.methodName.toSource() == 'useProvider') {
       final firstArgStaticType =
           node.argumentList.arguments.first.staticType.getDisplayString();
       // StateNotifierProvider

--- a/packages/riverpod_cli/lib/src/migrate/version.dart
+++ b/packages/riverpod_cli/lib/src/migrate/version.dart
@@ -1,7 +1,7 @@
 import 'package:codemod/codemod.dart';
 
 /// The lateste version of riverpod that migrated code should be updated to
-const latestVersion = '1.0.0-dev.0';
+const latestVersion = '0.14.0';
 
 /// Migrates the pubspec to the [latestVersion]
 Stream<Patch> versionMigrationSuggestor(FileContext context) async* {


### PR DESCRIPTION
This will make riverpod_cli pass CI. There were some minor changes you introduced with find-replace that caused it to break. #424 is the PR for updating the migration tool to migrate to the latest changes (though that also needs a bit more work before landing).