### PR TITLE
Migration 1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,9 @@ jobs:
         run: melos bootstrap
 
       - name: Install cli fixtures
-        run: cd packages/riverpod_cli/fixtures/notifiers/input && flutter pub get && cd -
+        run: |
+          cd packages/riverpod_cli/fixtures/notifiers/input && flutter pub get && cd -
+          cd packages/riverpod_cli/fixtures/unified_syntax/input && flutter pub get && cd -
 
       - name: Check format
         run: flutter format --set-exit-if-changed .

--- a/packages/riverpod_cli/CHANGELOG.md
+++ b/packages/riverpod_cli/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 0.0.2+2
+# 0.0.3
+- Migration for unifying syntax (riverpod 1.0.0) [RFC](https://github.com/rrousselGit/river_pod/issues/335)
 
+# 0.0.2+2
 - Fix migration for static final providers.
 
 # 0.0.2+1

--- a/packages/riverpod_cli/change_notifier_provider.tmp
+++ b/packages/riverpod_cli/change_notifier_provider.tmp
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class Counter extends ChangeNotifier {
+  Counter();
+  int _state = 0;
+  int get state => _state;
+  void increment() {
+    _state++;
+    notifyListeners();
+  }
+
+  void decrement() {
+    _state++;
+    notifyListeners();
+  }
+}
+
+final counterProvider = ChangeNotifierProvider((ref) => Counter());
+
+final otherProvider = Provider<Counter>((ref) {
+  ref.read(counterProvider);
+  return ref.watch(counterProvider);
+});
+
+class ConsumerWatch extends ConsumerWidget {
+  const ConsumerWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, ScopedReader watch) {
+    final count = watch(counterProvider);
+    return Center(
+      child: Text('$count'),
+    );
+  }
+}
+
+class HooksWatch extends HookWidget {
+  const HooksWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // ignore: unused_local_variable
+    final countNotifier = useProvider(counterProvider);
+    return Center(
+      child: ElevatedButton(
+        onPressed: () {
+          context.read(counterProvider);
+        },
+        child: const Text('Press Me'),
+      ),
+    );
+  }
+}

--- a/packages/riverpod_cli/fixtures/notifiers/golden/state_notifier_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/state_notifier_provider.dart
@@ -17,9 +17,21 @@ class Counter extends StateNotifier<int> {
   void decrement() => state--;
 }
 
+class CounterNullable extends StateNotifier<int?> {
+  CounterNullable(int? init) : super(init);
+
+  void increment() => state = state! + 1;
+  void decrement() => state = state! - 1;
+}
+
 final counterProvider = StateNotifierProvider<Counter, int>((ref) => Counter());
 final counterProvider2 =
     StateNotifierProvider<Counter, int>((ref) => Counter());
+final counterNullableProvider = StateNotifierProvider<CounterNullable, int?>(
+    (ref) => CounterNullable(null));
+final counterNullableProviderFamily =
+    StateNotifierProvider.family<CounterNullable, int?, int?>(
+        (ref, init) => CounterNullable(init));
 
 final counterFamilyProvider =
     StateNotifierProvider.family<Counter, int, String>((ref, _) => Counter());

--- a/packages/riverpod_cli/fixtures/notifiers/golden/state_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/state_provider.dart
@@ -7,6 +7,9 @@ import 'package:riverpod/riverpod.dart';
 
 final counterProvider = StateProvider((ref) => 1);
 final counterFamilyProvider = StateProvider.family<int, String>((ref, _) => 1);
+final counterNullProvider = StateProvider((ref) => null);
+final counterNullFamilyProvider =
+    StateProvider.family<int?, String?>((ref, _) => null);
 
 final otherProvider = Provider<int>((ref) {
   ref.read(counterProvider);

--- a/packages/riverpod_cli/fixtures/notifiers/input/state_notifier_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/input/state_notifier_provider.dart
@@ -17,8 +17,20 @@ class Counter extends StateNotifier<int> {
   void decrement() => state--;
 }
 
+class CounterNullable extends StateNotifier<int?> {
+  CounterNullable(int? init) : super(init);
+
+  void increment() => state = state! + 1;
+  void decrement() => state = state! - 1;
+}
+
 final counterProvider = StateNotifierProvider((ref) => Counter());
 final counterProvider2 = StateNotifierProvider<Counter>((ref) => Counter());
+final counterNullableProvider =
+    StateNotifierProvider<CounterNullable>((ref) => CounterNullable(null));
+final counterNullableProviderFamily =
+    StateNotifierProvider.family<CounterNullable, int?>(
+        (ref, init) => CounterNullable(init));
 
 final counterFamilyProvider =
     StateNotifierProvider.family<Counter, String>((ref, _) => Counter());

--- a/packages/riverpod_cli/fixtures/notifiers/input/state_provider.dart
+++ b/packages/riverpod_cli/fixtures/notifiers/input/state_provider.dart
@@ -7,6 +7,9 @@ import 'package:riverpod/riverpod.dart';
 
 final counterProvider = StateProvider((ref) => 1);
 final counterFamilyProvider = StateProvider.family<int, String>((ref, _) => 1);
+final counterNullProvider = StateProvider((ref) => null);
+final counterNullFamilyProvider =
+    StateProvider.family<int?, String?>((ref, _) => null);
 
 final otherProvider = Provider<int>((ref) {
   ref.read(counterProvider);

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec.yaml
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec.yaml
@@ -1,0 +1,14 @@
+name: codemod_riverpod_test_unified_syntax_golden
+description: Test riverpod codemods
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0-0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter  
+  flutter_riverpod: ^1.0.0
+  hooks_riverpod: ^1.0.0
+  riverpod: ^1.0.0

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec.yaml
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec.yaml
@@ -9,6 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter  
-  flutter_riverpod: ^1.0.0
-  hooks_riverpod: ^1.0.0
-  riverpod: ^1.0.0
+  flutter_riverpod: ^1.0.0-dev.1
+  hooks_riverpod: ^1.0.0-dev.1
+  riverpod: ^1.0.0-dev.1

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+// ignore_for_file: avoid_types_on_closure_parameters, type_init_formals, unused_local_variable, avoid_print
+
+class Counter extends StateNotifier<int> {
+  Counter(ProviderRefBase this.ref) : super(1);
+  final ProviderRefBase ref;
+  void increment() => state++;
+  void decrement() => state--;
+}
+
+final counterProvider =
+    StateNotifierProvider<Counter, int>((ref) => Counter(ref));
+final futureProvider = FutureProvider<int>((FutureProviderRef<int> ref) async {
+  await Future<void>.delayed(const Duration(seconds: 1));
+  return Future.value(0);
+});
+final streamProvider = StreamProvider<int>((StreamProviderRef<int> ref) async* {
+  yield 0;
+  await Future<void>.delayed(const Duration(seconds: 1));
+  yield 1;
+});
+final plainProvider = Provider<String>((ProviderRef<String> ref) => '');
+final plainNullProvider = Provider<String?>((ProviderRef<String?> ref) => null);
+final plainProviderAD =
+    Provider.autoDispose<String>((AutoDisposeProviderRef<String> ref) => '');
+final plainProviderFamilyAD = Provider.family
+    .autoDispose<String, String>((AutoDisposeProviderRef<String> ref, _) => '');
+final futureProviderAD = FutureProvider.autoDispose<String>(
+    (AutoDisposeFutureProviderRef<String> ref) async => '');
+final streamProviderAD = StreamProvider.autoDispose<String>(
+    (AutoDisposeStreamProviderRef<String> ref) =>
+        Stream.fromIterable(['1', '2', '3']));
+final stateNotifierProvider = StateNotifierProvider<Counter, int>(
+    (StateNotifierProviderRef<Counter, int> ref) => Counter(ref));
+
+class Logger extends ProviderObserver {
+  @override
+  void didUpdateProvider(
+      ProviderBase provider, Object? oldValue, Object? newValue) {
+    print('$provider $newValue');
+  }
+}
+
+class ConsumerWatch extends ConsumerWidget {
+  const ConsumerWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetReference ref) {
+    final countNotifier = ref.watch(counterProvider.notifier);
+    final count = ref.watch(counterProvider);
+    return Center(
+      child: Text('$count'),
+    );
+  }
+}
+
+class StatelessRead extends ConsumerWidget {
+  const StatelessRead({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetReference ref) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: () {
+          ref.read(counterProvider);
+          ref.refresh(counterProvider.notifier);
+        },
+        child: const Text('Counter'),
+      ),
+    );
+  }
+}
+
+class StatelessListen extends ConsumerWidget {
+  const StatelessListen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetReference ref) {
+    ref.listen(counterProvider, (context, i) {
+      print(i);
+    });
+    return const Text('Counter');
+  }
+}
+
+class StatelessExpressionListen extends ConsumerWidget {
+  const StatelessExpressionListen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetReference ref) {
+    ref.listen(counterProvider, (context, i) {
+      print(i);
+    });
+    return const Text('Counter');
+  }
+}
+
+class StatefulConsumer extends ConsumerStatefulWidget {
+  const StatefulConsumer({Key? key}) : super(key: key);
+
+  @override
+  _StatefulConsumerState createState() => _StatefulConsumerState();
+}
+
+class _StatefulConsumerState extends State<StatefulConsumer>
+    with ConsumerStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: GestureDetector(
+        onTap: () {
+          ref.refresh(counterProvider.notifier);
+          ref.refresh(futureProvider.future);
+          ref.refresh(streamProvider.future);
+        },
+        child: Consumer(
+          builder: (context, ref, child) {
+            return Text('${ref.watch(counterProvider)}');
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _StatefulConsumerState2 extends State<StatefulConsumer2>
+    with ConsumerStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: GestureDetector(
+        onTap: () {
+          ref.refresh(counterProvider.notifier);
+        },
+        child: const Text('Hi'),
+      ),
+    );
+  }
+}
+
+class StatefulConsumer2 extends ConsumerStatefulWidget {
+  const StatefulConsumer2({Key? key}) : super(key: key);
+
+  @override
+  _StatefulConsumerState2 createState() => _StatefulConsumerState2();
+}
+
+class HooksWatch extends HookConsumerWidget {
+  const HooksWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetReference ref) {
+    final countNotifier = ref.watch(counterProvider.notifier);
+    final count = ref.watch(counterProvider);
+    return Center(
+      child: ElevatedButton(
+        onPressed: () {
+          ref.read(counterProvider.notifier);
+          ref.read(counterProvider);
+        },
+        child: const Text('Press Me'),
+      ),
+    );
+  }
+}
+
+class HooksConsumerWatch extends StatelessWidget {
+  const HooksConsumerWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: HookConsumer(
+        builder: (context, ref, child) {
+          ref.watch(counterProvider);
+          return ElevatedButton(
+            onPressed: () {
+              ref.read(counterProvider.notifier);
+              ref.read(counterProvider);
+            },
+            child: const Text('Press Me'),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class BasicUseOfCustomHook extends HookConsumerWidget {
+  const BasicUseOfCustomHook({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context, WidgetReference ref) {
+    useAnotherHook(ref);
+    return Container();
+  }
+}
+
+Object useMyHook(WidgetReference ref) {
+  return ref.watch(counterProvider);
+}
+
+void useAnotherHook(WidgetReference ref) {
+  useMyHook(ref);
+}

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
@@ -1,9 +1,9 @@
+// ignore_for_file: avoid_types_on_closure_parameters, type_init_formals, unused_local_variable, avoid_print, unnecessary_lambdas, unused_import
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod/riverpod.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-// ignore_for_file: avoid_types_on_closure_parameters, type_init_formals, unused_local_variable, avoid_print
 
 class Counter extends StateNotifier<int> {
   Counter(ProviderRefBase this.ref) : super(1);
@@ -49,7 +49,7 @@ class ConsumerWatch extends ConsumerWidget {
   const ConsumerWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetReference ref) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final countNotifier = ref.watch(counterProvider.notifier);
     final count = ref.watch(counterProvider);
     return Center(
@@ -62,7 +62,7 @@ class StatelessRead extends ConsumerWidget {
   const StatelessRead({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetReference ref) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Center(
       child: ElevatedButton(
         onPressed: () {
@@ -79,8 +79,8 @@ class StatelessListen extends ConsumerWidget {
   const StatelessListen({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetReference ref) {
-    ref.listen(counterProvider, (context, i) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen(counterProvider, (i) {
       print(i);
     });
     return const Text('Counter');
@@ -91,11 +91,13 @@ class StatelessExpressionListen extends ConsumerWidget {
   const StatelessExpressionListen({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetReference ref) {
-    ref.listen(counterProvider, (context, i) {
-      print(i);
-    });
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen(counterProvider, onChange);
     return const Text('Counter');
+  }
+
+  void onChange(int i) {
+    print(i);
   }
 }
 
@@ -106,8 +108,7 @@ class StatefulConsumer extends ConsumerStatefulWidget {
   _StatefulConsumerState createState() => _StatefulConsumerState();
 }
 
-class _StatefulConsumerState extends State<StatefulConsumer>
-    with ConsumerStateMixin {
+class _StatefulConsumerState extends ConsumerState<StatefulConsumer> {
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -115,7 +116,7 @@ class _StatefulConsumerState extends State<StatefulConsumer>
         onTap: () {
           ref.refresh(counterProvider.notifier);
           ref.refresh(futureProvider.future);
-          ref.refresh(streamProvider.future);
+          ref.refresh(streamProvider);
         },
         child: Consumer(
           builder: (context, ref, child) {
@@ -127,8 +128,7 @@ class _StatefulConsumerState extends State<StatefulConsumer>
   }
 }
 
-class _StatefulConsumerState2 extends State<StatefulConsumer2>
-    with ConsumerStateMixin {
+class _StatefulConsumerState2 extends ConsumerState<StatefulConsumer2> {
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -153,7 +153,7 @@ class HooksWatch extends HookConsumerWidget {
   const HooksWatch({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetReference ref) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final countNotifier = ref.watch(counterProvider.notifier);
     final count = ref.watch(counterProvider);
     return Center(
@@ -193,16 +193,16 @@ class HooksConsumerWatch extends StatelessWidget {
 class BasicUseOfCustomHook extends HookConsumerWidget {
   const BasicUseOfCustomHook({Key? key}) : super(key: key);
   @override
-  Widget build(BuildContext context, WidgetReference ref) {
+  Widget build(BuildContext context, WidgetRef ref) {
     useAnotherHook(ref);
     return Container();
   }
 }
 
-Object useMyHook(WidgetReference ref) {
+Object useMyHook(WidgetRef ref) {
   return ref.watch(counterProvider);
 }
 
-void useAnotherHook(WidgetReference ref) {
+void useAnotherHook(WidgetRef ref) {
   useMyHook(ref);
 }

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
@@ -206,3 +206,12 @@ Object useMyHook(WidgetRef ref) {
 void useAnotherHook(WidgetRef ref) {
   useMyHook(ref);
 }
+
+class NoMigrateHook extends HookWidget {
+  const NoMigrateHook({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    final state = useState('');
+    return Container();
+  }
+}

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/pubspec.yaml
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/pubspec.yaml
@@ -1,0 +1,14 @@
+name: codemod_riverpod_test_unified_syntax
+description: Test riverpod codemods
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0-0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter  
+  flutter_riverpod: ^0.14.0+1
+  hooks_riverpod: ^0.14.0+1
+  riverpod: ^0.14.0+1

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
@@ -1,9 +1,9 @@
+// ignore_for_file: avoid_types_on_closure_parameters, type_init_formals, unused_local_variable, avoid_print, unnecessary_lambdas, unused_import
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod/riverpod.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-// ignore_for_file: avoid_types_on_closure_parameters, type_init_formals, unused_local_variable, avoid_print
 
 class Counter extends StateNotifier<int> {
   Counter(ProviderReference this.ref) : super(1);
@@ -93,11 +93,13 @@ class StatelessExpressionListen extends StatelessWidget {
   @override
   Widget build(BuildContext context) => ProviderListener(
         provider: counterProvider,
-        onChange: (context, i) {
-          print(i);
-        },
+        onChange: onChange,
         child: const Text('Counter'),
       );
+
+  void onChange(BuildContext context, int i) {
+    print(i);
+  }
 }
 
 class StatefulConsumer extends StatefulWidget {

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+// ignore_for_file: avoid_types_on_closure_parameters, type_init_formals, unused_local_variable, avoid_print
+
+class Counter extends StateNotifier<int> {
+  Counter(ProviderReference this.ref) : super(1);
+  final ProviderReference ref;
+  void increment() => state++;
+  void decrement() => state--;
+}
+
+final counterProvider =
+    StateNotifierProvider<Counter, int>((ref) => Counter(ref));
+final futureProvider = FutureProvider((ProviderReference ref) async {
+  await Future<void>.delayed(const Duration(seconds: 1));
+  return Future.value(0);
+});
+final streamProvider = StreamProvider((ProviderReference ref) async* {
+  yield 0;
+  await Future<void>.delayed(const Duration(seconds: 1));
+  yield 1;
+});
+final plainProvider = Provider((ProviderReference ref) => '');
+final plainNullProvider = Provider<String?>((ProviderReference ref) => null);
+final plainProviderAD = Provider.autoDispose((ProviderReference ref) => '');
+final plainProviderFamilyAD = Provider.family
+    .autoDispose<String, String>((ProviderReference ref, _) => '');
+final futureProviderAD =
+    FutureProvider.autoDispose((ProviderReference ref) async => '');
+final streamProviderAD = StreamProvider.autoDispose(
+    (ProviderReference ref) => Stream.fromIterable(['1', '2', '3']));
+final stateNotifierProvider = StateNotifierProvider<Counter, int>(
+    (ProviderReference ref) => Counter(ref));
+
+class Logger extends ProviderObserver {
+  @override
+  void didUpdateProvider(ProviderBase provider, Object? newValue) {
+    print('$provider $newValue');
+  }
+}
+
+class ConsumerWatch extends ConsumerWidget {
+  const ConsumerWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, ScopedReader watch) {
+    final countNotifier = watch(counterProvider.notifier);
+    final count = watch(counterProvider);
+    return Center(
+      child: Text('$count'),
+    );
+  }
+}
+
+class StatelessRead extends StatelessWidget {
+  const StatelessRead({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+        onPressed: () {
+          context.read(counterProvider);
+          context.refresh(counterProvider);
+        },
+        child: const Text('Counter'),
+      ),
+    );
+  }
+}
+
+class StatelessListen extends StatelessWidget {
+  const StatelessListen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderListener(
+      provider: counterProvider,
+      onChange: (context, i) {
+        print(i);
+      },
+      child: const Text('Counter'),
+    );
+  }
+}
+
+class StatelessExpressionListen extends StatelessWidget {
+  const StatelessExpressionListen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => ProviderListener(
+        provider: counterProvider,
+        onChange: (context, i) {
+          print(i);
+        },
+        child: const Text('Counter'),
+      );
+}
+
+class StatefulConsumer extends StatefulWidget {
+  const StatefulConsumer({Key? key}) : super(key: key);
+
+  @override
+  _StatefulConsumerState createState() => _StatefulConsumerState();
+}
+
+class _StatefulConsumerState extends State<StatefulConsumer> {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: GestureDetector(
+        onTap: () {
+          context.refresh(counterProvider);
+          context.refresh(futureProvider);
+          context.refresh(streamProvider);
+        },
+        child: Consumer(
+          builder: (context, watch, child) {
+            return Text('${watch(counterProvider)}');
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _StatefulConsumerState2 extends State<StatefulConsumer2> {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: GestureDetector(
+        onTap: () {
+          context.refresh(counterProvider);
+        },
+        child: const Text('Hi'),
+      ),
+    );
+  }
+}
+
+class StatefulConsumer2 extends StatefulWidget {
+  const StatefulConsumer2({Key? key}) : super(key: key);
+
+  @override
+  _StatefulConsumerState2 createState() => _StatefulConsumerState2();
+}
+
+class HooksWatch extends HookWidget {
+  const HooksWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final countNotifier = useProvider(counterProvider.notifier);
+    final count = useProvider(counterProvider);
+    return Center(
+      child: ElevatedButton(
+        onPressed: () {
+          context.read(counterProvider.notifier);
+          context.read(counterProvider);
+        },
+        child: const Text('Press Me'),
+      ),
+    );
+  }
+}
+
+class HooksConsumerWatch extends StatelessWidget {
+  const HooksConsumerWatch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: HookBuilder(
+        builder: (context) {
+          useProvider(counterProvider);
+          return ElevatedButton(
+            onPressed: () {
+              context.read(counterProvider.notifier);
+              context.read(counterProvider);
+            },
+            child: const Text('Press Me'),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class BasicUseOfCustomHook extends HookWidget {
+  const BasicUseOfCustomHook({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    useAnotherHook();
+    return Container();
+  }
+}
+
+Object useMyHook() {
+  return useProvider(counterProvider);
+}
+
+void useAnotherHook() {
+  useMyHook();
+}

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
@@ -207,3 +207,12 @@ Object useMyHook() {
 void useAnotherHook() {
   useMyHook();
 }
+
+class NoMigrateHook extends HookWidget {
+  const NoMigrateHook({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    final state = useState('');
+    return Container();
+  }
+}

--- a/packages/riverpod_cli/lib/src/migrate.dart
+++ b/packages/riverpod_cli/lib/src/migrate.dart
@@ -5,10 +5,10 @@ import 'package:codemod/codemod.dart';
 import 'package:glob/glob.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
-import 'package:riverpod_cli/src/migrate/unified_syntax.dart';
 
 import 'migrate/imports.dart';
 import 'migrate/notifiers.dart';
+import 'migrate/unified_syntax.dart';
 import 'migrate/version.dart';
 
 class MigrateCommand extends Command<void> {

--- a/packages/riverpod_cli/lib/src/migrate/imports.dart
+++ b/packages/riverpod_cli/lib/src/migrate/imports.dart
@@ -1,5 +1,6 @@
 // ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
 
 /// A suggestor that yields changes to deprecated import directives

--- a/packages/riverpod_cli/lib/src/migrate/notifiers.dart
+++ b/packages/riverpod_cli/lib/src/migrate/notifiers.dart
@@ -1,4 +1,7 @@
 // ignore: deprecated_member_use
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:codemod/codemod.dart';
@@ -23,23 +26,23 @@ class RiverpodNotifierChangesMigrationSuggestor
 
   @override
   void visitInvocationExpression(InvocationExpression node) {
-    final nodeType = node.staticType.getDisplayString();
+    final nodeType = node.staticType!.getDisplayString(withNullability: true);
     if (nodeType.contains('StateNotifierProvider')) {
-      final providerType = node.staticType as InterfaceType;
-      final notifierType = providerType.typeArguments.first as InterfaceType;
-      final stateType = notifierType.superclass.typeArguments.first;
+      final providerType = node.staticType as InterfaceType?;
+      final notifierType = providerType!.typeArguments.first as InterfaceType?;
+      final stateType = notifierType!.superclass!.typeArguments.first;
 
       if (nodeType.contains('Family')) {
         yieldPatch(
-            '<${notifierType.getDisplayString()}, ${stateType.getDisplayString()}, ${providerType.typeArguments.last.getDisplayString()}>',
-            node.typeArguments.offset,
+            '<${notifierType.getDisplayString(withNullability: true)}, ${stateType.getDisplayString(withNullability: true)}, ${providerType.typeArguments.last.getDisplayString(withNullability: true)}>',
+            node.typeArguments!.offset,
             node.argumentList.offset);
       } else {
         if (node.parent is VariableDeclaration) {
           // Make sure it is variable declaration so we don't add type params
           // on family accesses
           yieldPatch(
-              '<${notifierType.getDisplayString()}, ${stateType.getDisplayString()}>',
+              '<${notifierType.getDisplayString(withNullability: true)}, ${stateType.getDisplayString(withNullability: true)}>',
               node.function.end,
               node.argumentList.offset);
         }
@@ -51,14 +54,14 @@ class RiverpodNotifierChangesMigrationSuggestor
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    final nodeType = node.staticType.getDisplayString();
+    final nodeType = node.staticType!.getDisplayString(withNullability: true);
     if (nodeType.contains('StateNotifierProvider')) {
-      final providerType = node.staticType as InterfaceType;
-      final notifierType = providerType.typeArguments.first as InterfaceType;
-      final stateType = notifierType.superclass.typeArguments.first;
+      final providerType = node.staticType as InterfaceType?;
+      final notifierType = providerType!.typeArguments.first as InterfaceType?;
+      final stateType = notifierType!.superclass!.typeArguments.first;
       final constructorTypeArguments = node.constructorName.type.typeArguments;
       yieldPatch(
-          '<${notifierType.getDisplayString()}, ${stateType.getDisplayString()}>',
+          '<${notifierType.getDisplayString(withNullability: true)}, ${stateType.getDisplayString(withNullability: true)}>',
           constructorTypeArguments != null
               ? constructorTypeArguments.offset
               : node.constructorName.end,
@@ -77,8 +80,8 @@ class RiverpodNotifierChangesMigrationSuggestor
     // context.read(provider.state) => context.read(provider)
     // useProvider(provider.state) => useProvider(provider)
     if (node.identifier.name == 'state') {
-      if (node.prefix.staticType
-          .getDisplayString()
+      if (node.prefix.staticType!
+          .getDisplayString(withNullability: true)
           .contains('StateNotifierProvider')) {
         yieldPatch('', node.prefix.end, node.end);
       }
@@ -90,8 +93,8 @@ class RiverpodNotifierChangesMigrationSuggestor
   void visitPropertyAccess(PropertyAccess node) {
     // ref.watch(Static.provider.state) => ref.watch(provider)
     if (node.propertyName.name == 'state') {
-      if (node.realTarget.staticType
-          .getDisplayString()
+      if (node.realTarget.staticType!
+          .getDisplayString(withNullability: true)
           .contains('StateNotifierProvider')) {
         yieldPatch('', node.realTarget.end, node.end);
       }
@@ -104,8 +107,8 @@ class RiverpodNotifierChangesMigrationSuggestor
     if (node.function.toSource() == 'read' ||
         node.function.toSource() == 'watch' ||
         node.function.toSource() == 'useProvider') {
-      final firstArgStaticType =
-          node.argumentList.arguments.first.staticType.getDisplayString();
+      final firstArgStaticType = node.argumentList.arguments.first.staticType!
+          .getDisplayString(withNullability: true);
       if (firstArgStaticType.contains('StateNotifierProvider')) {
         // StateNotifierProvider
         // watch(provider) => watch(provider.notifier)
@@ -123,8 +126,8 @@ class RiverpodNotifierChangesMigrationSuggestor
     if (node.methodName.toSource() == 'read' ||
         node.methodName.toSource() == 'watch' ||
         node.methodName.toSource() == 'useProvider') {
-      final firstArgStaticType =
-          node.argumentList.arguments.first.staticType.getDisplayString();
+      final firstArgStaticType = node.argumentList.arguments.first.staticType!
+          .getDisplayString(withNullability: true);
       // StateNotifierProvider
       if (firstArgStaticType.contains('StateNotifierProvider')) {
         // ref.watch(provider) => ref.watch(provider.notifier)

--- a/packages/riverpod_cli/lib/src/migrate/notifiers.dart
+++ b/packages/riverpod_cli/lib/src/migrate/notifiers.dart
@@ -1,8 +1,6 @@
 // ignore: deprecated_member_use
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-
-import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:codemod/codemod.dart';
 import 'package:pub_semver/pub_semver.dart';

--- a/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
+++ b/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
@@ -30,7 +30,7 @@ class RiverpodHooksProviderInfo extends GeneralizingAstVisitor<void>
 
   static bool shouldMigrate(String functionName) {
     _propagateDependencies();
-    return isConsumerHookFunction[functionName]!;
+    return isConsumerHookFunction[functionName] ?? false;
   }
 
   static void _propagateDependencies() {
@@ -135,6 +135,7 @@ class RiverpodUnifiedSyntaxChangesMigrationSuggestor
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
+    methodDecls.clear();
     final name = node.extendsClause?.superclass.name.name;
     classDeclaration = node;
     if (name == 'StatelessWidget') {

--- a/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
+++ b/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
@@ -1,0 +1,554 @@
+// ignore: deprecated_member_use
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:codemod/codemod.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import 'package:pub_semver/pub_semver.dart';
+
+enum ClassType { consumer, hook, stateless, stateful, none }
+enum ProviderType {
+  stream,
+  future,
+  plain,
+  state,
+  statenotifier,
+  changenotifier,
+  none
+}
+
+/// Aggregates information needed for the unified syntax change with hooks
+///
+/// Runs before [RiverpodUnifiedSyntaxChangesMigrationSuggestor]
+class RiverpodHooksProviderInfo extends GeneralizingAstVisitor<void>
+    with AstVisitingSuggestor {
+  RiverpodHooksProviderInfo(this.riverpodVersion);
+  final VersionConstraint riverpodVersion;
+  static Map<String, bool> isConsumerHookFunction = {};
+  static Map<String, Set<String>> hookDependencies = {};
+  FunctionDeclaration? currentFunction;
+  static bool computedDependencies = false;
+
+  static bool shouldMigrate(String functionName) {
+    _propagateDependencies();
+    return isConsumerHookFunction[functionName]!;
+  }
+
+  static void _propagateDependencies() {
+    if (computedDependencies) {
+      return;
+    }
+    var changed = true;
+    while (changed) {
+      changed = false;
+      for (final entry in isConsumerHookFunction.entries) {
+        if (entry.value) {
+          for (final dependency in hookDependencies.entries) {
+            if (dependency.value.contains(entry.key) &&
+                !isConsumerHookFunction[dependency.key]!) {
+              isConsumerHookFunction[dependency.key] = true;
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+    computedDependencies = true;
+  }
+
+  @override
+  bool shouldResolveAst(FileContext context) => true;
+
+  @override
+  bool shouldSkip(FileContext context) {
+    return riverpodVersion.allowsAny(
+      VersionConstraint.parse('^1.0.0'),
+    );
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    currentFunction = node;
+    isConsumerHookFunction[currentFunction!.name.name] = false;
+    hookDependencies[currentFunction!.name.name] = {};
+    super.visitFunctionDeclaration(node);
+    currentFunction = null;
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    final functionName = node.function.toSource();
+    if (functionName.startsWith('use') && currentFunction != null) {
+      hookDependencies[currentFunction!.name.name]!.add(functionName);
+      if (functionName == 'useProvider') {
+        isConsumerHookFunction[currentFunction!.name.name] = true;
+      }
+    }
+    super.visitFunctionExpressionInvocation(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final functionName = node.methodName.toSource();
+    if (currentFunction != null) {
+      if (functionName.startsWith('use')) {
+        hookDependencies[currentFunction!.name.name]!.add(functionName);
+        if (functionName == 'useProvider') {
+          hookDependencies[currentFunction!.name.name]!.add(functionName);
+          isConsumerHookFunction[currentFunction!.name.name] = true;
+        }
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+}
+
+/// A suggestor that yields changes to notifier changes
+class RiverpodUnifiedSyntaxChangesMigrationSuggestor
+    extends GeneralizingAstVisitor<void> with AstVisitingSuggestor {
+  RiverpodUnifiedSyntaxChangesMigrationSuggestor(this.riverpodVersion);
+
+  final VersionConstraint riverpodVersion;
+
+  @override
+  bool shouldSkip(FileContext context) {
+    return riverpodVersion.allowsAny(
+      VersionConstraint.parse('^1.0.0'),
+    );
+  }
+
+  @override
+  bool shouldResolveAst(FileContext context) => true;
+
+  ClassType withinClass = ClassType.none;
+  ClassDeclaration? classDeclaration;
+  FormalParameterList? params;
+  FunctionBody? functionBody;
+  ConstructorName? hookBuilder;
+  bool inConsumerBuilder = false;
+  bool inHookBuilder = false;
+  bool lookingForParams = false;
+  final Map<String, ClassDeclaration> statefulDeclarations = {};
+  final Set<String> statefulNeedsMigration = {};
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    final name = node.extendsClause?.superclass.name.name;
+    classDeclaration = node;
+    if (name == 'StatelessWidget') {
+      withinClass = ClassType.stateless;
+    } else if (name == 'State') {
+      withinClass = ClassType.stateful;
+    } else if (name == 'ConsumerWidget') {
+      withinClass = ClassType.consumer;
+    } else if (name == 'HookWidget') {
+      withinClass = ClassType.hook;
+    } else {
+      withinClass = ClassType.none;
+      classDeclaration = null;
+    }
+    if (name == 'StatefulWidget') {
+      statefulDeclarations[node.name.name] = node;
+      if (statefulNeedsMigration.contains(node.name.name)) {
+        migrateStateful(node.name.name);
+      }
+    }
+    super.visitClassDeclaration(node);
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (node.name.name == 'build') {
+      params = node.parameters;
+      functionBody = node.body;
+      if (withinClass == ClassType.consumer) {
+        // Consumer should be migrated regardless if providers are watched / read or not
+        migrateParams();
+      }
+    } else if (node.name.name == 'didUpdateProvider') {
+      yieldPatch(', Object? oldValue, ', node.parameters!.parameters.first.end,
+          node.parameters!.parameters.last.offset);
+    }
+    super.visitMethodDeclaration(node);
+  }
+
+  void migrateParams() {
+    final params = this.params;
+    if (params != null) {
+      if (inConsumerBuilder) {
+        assert(
+          params.parameters.length == 3,
+          'Consumers should have a parameter list of length 3',
+        );
+        yieldPatch(
+          'ref',
+          params.parameters[1].offset,
+          params.parameters[1].end,
+        );
+      } else if (inHookBuilder) {
+        assert(
+          params.parameters.length == 1,
+          'HookBuilders should have a parameter list of length 1, $params',
+        );
+        yieldPatch('HookConsumer', hookBuilder!.offset, hookBuilder!.end);
+        yieldPatch(
+          ', ref, child',
+          params.parameters.first.end,
+          params.parameters.first.end,
+        );
+      } else if (withinClass != ClassType.stateful) {
+        // In build method
+        if (params.parameters.length == 2) {
+          // Consumer
+          yieldPatch(
+            'WidgetReference ref',
+            params.parameters.last.offset,
+            params.parameters.last.end,
+          );
+        }
+        if (params.parameters.length == 1) {
+          // Stateless, Hook
+          yieldPatch(
+            ', WidgetReference ref',
+            params.parameters.last.end,
+            params.parameters.last.end,
+          );
+        }
+      }
+      this.params = null;
+    }
+  }
+
+  void migrateClass() {
+    final classDecl = classDeclaration;
+    if (classDecl != null && !inHookBuilder && !inConsumerBuilder) {
+      if (withinClass == ClassType.hook) {
+        yieldPatch(
+          'HookConsumerWidget',
+          classDecl.extendsClause!.superclass.offset,
+          classDecl.extendsClause!.superclass.end,
+        );
+      } else if (withinClass == ClassType.stateless) {
+        yieldPatch(
+          'ConsumerWidget',
+          classDecl.extendsClause!.superclass.offset,
+          classDecl.extendsClause!.superclass.end,
+        );
+      } else if (withinClass == ClassType.stateful) {
+        if (classDecl.withClause == null) {
+          yieldPatch(
+            ' with ConsumerStateMixin',
+            classDecl.extendsClause!.superclass.end,
+            classDecl.extendsClause!.superclass.end,
+          );
+        } else {
+          yieldPatch(
+            ', ConsumerStateMixin',
+            classDecl.withClause!.mixinTypes.last.end,
+            classDecl.withClause!.mixinTypes.last.end,
+          );
+        }
+        migrateStateful(classDecl
+            .extendsClause!.superclass.typeArguments!.arguments.first.type!
+            .getDisplayString(withNullability: true));
+      }
+      classDeclaration = null;
+    }
+  }
+
+  void migrateConsumerHookFunctionCall(ArgumentList argumentList) {
+    if (argumentList.arguments.isNotEmpty) {
+      yieldPatch('ref, ', argumentList.arguments.first.offset,
+          argumentList.arguments.first.offset);
+    } else {
+      yieldPatch('ref', argumentList.leftParenthesis.end,
+          argumentList.rightParenthesis.offset);
+    }
+  }
+
+  void migrateFunctionDeclaration(FunctionDeclaration node) {
+    if (node.functionExpression.parameters!.parameters.isNotEmpty) {
+      yieldPatch(
+          'WidgetReference ref, ',
+          node.functionExpression.parameters!.parameters.first.offset,
+          node.functionExpression.parameters!.parameters.first.offset);
+    } else {
+      yieldPatch(
+          'WidgetReference ref',
+          node.functionExpression.parameters!.leftParenthesis.end,
+          node.functionExpression.parameters!.rightParenthesis.offset);
+    }
+  }
+
+  @override
+  void visitFunctionExpression(FunctionExpression node) {
+    if ((inConsumerBuilder || inHookBuilder) && lookingForParams) {
+      params = node.parameters;
+      lookingForParams = false;
+    }
+    super.visitFunctionExpression(node);
+  }
+
+  void migrateListener(InstanceCreationExpression node) {
+    final provider = node.argumentList.arguments.firstWhere((element) =>
+            element is NamedExpression && element.name.label.name == 'provider')
+        as NamedExpression;
+    final onChange = node.argumentList.arguments.firstWhere((element) =>
+            element is NamedExpression && element.name.label.name == 'onChange')
+        as NamedExpression;
+    final fn = functionBody;
+    final providerSource = context.sourceText
+        .substring(provider.expression.offset, provider.expression.end);
+    final onChangeSource = context.sourceText
+        .substring(onChange.expression.offset, onChange.expression.end);
+
+    final child = node.argumentList.arguments.firstWhere((element) =>
+            element is NamedExpression && element.name.label.name == 'child')
+        as NamedExpression;
+    final childSource = context.sourceText
+        .substring(child.expression.offset, child.expression.end);
+    if (fn is BlockFunctionBody) {
+      yieldPatch('ref.listen($providerSource, $onChangeSource);',
+          fn.block.leftBracket.end, fn.block.leftBracket.end);
+    } else if (fn is ExpressionFunctionBody) {
+      yieldPatch('{\nref.listen($providerSource, $onChangeSource);return ',
+          fn.offset, fn.expression.offset);
+      yieldPatch(';}', fn.endToken.offset, fn.endToken.end);
+    }
+
+    yieldPatch(childSource, node.offset, node.end);
+  }
+
+  ProviderType inProvider = ProviderType.none;
+  bool inAutoDisposeProvider = false;
+  String providerTypeArgs = '';
+  @override
+  void visitTypeName(TypeName node) {
+    final typeName = node.type!.getDisplayString(withNullability: true);
+    if (typeName.contains('ProviderReference')) {
+      final autoDisposePrefix = inAutoDisposeProvider ? 'AutoDispose' : '';
+      switch (inProvider) {
+        case ProviderType.stream:
+          yieldPatch('${autoDisposePrefix}StreamProviderRef<$providerTypeArgs>',
+              node.name.offset, node.name.end);
+          break;
+        case ProviderType.future:
+          yieldPatch('${autoDisposePrefix}FutureProviderRef<$providerTypeArgs>',
+              node.name.offset, node.name.end);
+          break;
+        case ProviderType.plain:
+          yieldPatch('${autoDisposePrefix}ProviderRef<$providerTypeArgs>',
+              node.name.offset, node.name.end);
+          break;
+        case ProviderType.state:
+          yieldPatch('${autoDisposePrefix}StateProviderRef<$providerTypeArgs>',
+              node.name.offset, node.name.end);
+          break;
+        case ProviderType.statenotifier:
+          yieldPatch(
+              '${autoDisposePrefix}StateNotifierProviderRef<$providerTypeArgs>',
+              node.name.offset,
+              node.name.end);
+          break;
+        case ProviderType.changenotifier:
+          yieldPatch(
+              '${autoDisposePrefix}ChangeNotifierProviderRef<$providerTypeArgs>',
+              node.name.offset,
+              node.name.end);
+          break;
+        case ProviderType.none:
+          yieldPatch('ProviderRefBase', node.name.offset, node.name.end);
+          break;
+      }
+    }
+    super.visitTypeName(node);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final type = node.staticType!.getDisplayString(withNullability: true);
+    if (type.contains('Consumer')) {
+      inConsumerBuilder = true;
+      lookingForParams = true;
+    }
+    if (type.contains('HookBuilder')) {
+      inHookBuilder = true;
+      lookingForParams = true;
+      hookBuilder = node.constructorName;
+    }
+    if (type.contains('ProviderListener')) {
+      migrateListener(node);
+      migrateParams();
+      migrateClass();
+    } else if (!type.contains('Family') && type.contains('Provider')) {
+      yieldPatch(type, node.constructorName.offset, node.constructorName.end);
+    }
+    if (type.contains('FutureProvider')) {
+      inProvider = ProviderType.future;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('StreamProvider')) {
+      inProvider = ProviderType.stream;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('StateNotifierProvider')) {
+      inProvider = ProviderType.statenotifier;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('ChangeNotifierProvider')) {
+      inProvider = ProviderType.changenotifier;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('StateProvider')) {
+      inProvider = ProviderType.state;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('Provider')) {
+      inProvider = ProviderType.plain;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else {
+      inProvider = ProviderType.none;
+    }
+    if (type.contains('AutoDispose')) {
+      inAutoDisposeProvider = true;
+    }
+    super.visitInstanceCreationExpression(node);
+    inProvider = ProviderType.none;
+    inConsumerBuilder = false;
+    inHookBuilder = false;
+    inAutoDisposeProvider = false;
+  }
+
+  @override
+  void visitInvocationExpression(InvocationExpression node) {
+    final type = node.staticType!.getDisplayString(withNullability: true);
+
+    if (type.contains('FutureProvider')) {
+      inProvider = ProviderType.future;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('StreamProvider')) {
+      inProvider = ProviderType.stream;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('StateNotifierProvider')) {
+      inProvider = ProviderType.statenotifier;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('ChangeNotifierProvider')) {
+      inProvider = ProviderType.changenotifier;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('StateProvider')) {
+      inProvider = ProviderType.state;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else if (type.contains('Provider')) {
+      inProvider = ProviderType.plain;
+      providerTypeArgs =
+          type.substring(type.indexOf('<') + 1, type.lastIndexOf('>'));
+    } else {
+      inProvider = ProviderType.none;
+    }
+    if (type.contains('AutoDispose')) {
+      inAutoDisposeProvider = true;
+    }
+    if (type.contains('Family')) {
+      // Too many type args for ProviderRef
+      providerTypeArgs =
+          providerTypeArgs.substring(0, providerTypeArgs.lastIndexOf(','));
+    }
+    // Add type parameters if not already there
+    if (!type.contains('Family') &&
+        type.contains('Provider') &&
+        !type.contains('ProviderScope') &&
+        !type.contains('ProviderListener')) {
+      if (node.typeArguments == null) {
+        yieldPatch('<$providerTypeArgs>', node.argumentList.offset,
+            node.argumentList.offset);
+      }
+    }
+    super.visitInvocationExpression(node);
+    inProvider = ProviderType.none;
+    inAutoDisposeProvider = false;
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    final functionName = node.function.toSource();
+    if (functionName == 'watch' || functionName == 'useProvider') {
+      migrateParams();
+      migrateClass();
+
+      // watch(provider) => watch(provider.notifier)
+      // useProvider(provider) => useProvider(provider.notifier)
+      yieldPatch('ref.watch', node.function.offset, node.function.end);
+    } else if (functionName.startsWith('use')) {
+      if (RiverpodHooksProviderInfo.shouldMigrate(functionName)) {
+        migrateConsumerHookFunctionCall(node.argumentList);
+        migrateClass();
+      }
+    }
+
+    super.visitFunctionExpressionInvocation(node);
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    final functionName = node.name.name;
+    if (RiverpodHooksProviderInfo.shouldMigrate(functionName)) {
+      migrateFunctionDeclaration(node);
+    }
+    super.visitFunctionDeclaration(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final functionName = node.methodName.toSource();
+    // ref.read / ref.watch / context.read / context.watch, useProvider
+    if (functionName == 'watch' || functionName == 'useProvider') {
+      migrateParams();
+      migrateClass();
+      yieldPatch('ref.watch', node.offset, node.methodName.end);
+    } else if (functionName == 'read') {
+      migrateParams();
+      migrateClass();
+      yieldPatch('ref.read', node.offset, node.methodName.end);
+    } else if (functionName == 'refresh') {
+      migrateParams();
+      migrateClass();
+      yieldPatch('ref.refresh', node.offset, node.methodName.end);
+      final firstArgStaticType = node.argumentList.arguments.first.staticType!
+          .getDisplayString(withNullability: true);
+      if (firstArgStaticType.contains('FutureProvider') ||
+          firstArgStaticType.contains('StreamProvider')) {
+        // StateNotifierProvider
+        // watch(provider) => watch(provider.notifier)
+        // useProvider(provider) => useProvider(provider.notifier)
+        yieldPatch('.future', node.argumentList.arguments.first.end,
+            node.argumentList.arguments.first.end);
+      } else if (firstArgStaticType.contains('StateNotifier')) {
+        yieldPatch('.notifier', node.argumentList.arguments.first.end,
+            node.argumentList.arguments.first.end);
+      }
+    } else if (functionName.startsWith('use')) {
+      if (RiverpodHooksProviderInfo.shouldMigrate(functionName)) {
+        migrateConsumerHookFunctionCall(node.argumentList);
+        migrateClass();
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+
+  void migrateStateful(String statefulName) {
+    final statefulDeclaration = statefulDeclarations[statefulName];
+    if (statefulDeclaration != null) {
+      yieldPatch(
+          'ConsumerStatefulWidget',
+          statefulDeclaration.extendsClause!.superclass.offset,
+          statefulDeclaration.extendsClause!.superclass.end);
+    } else {
+      statefulNeedsMigration.add(statefulName);
+    }
+  }
+}

--- a/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
+++ b/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
@@ -1,6 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:codemod/codemod.dart';
 import 'package:pub_semver/pub_semver.dart';

--- a/packages/riverpod_cli/lib/src/migrate/version.dart
+++ b/packages/riverpod_cli/lib/src/migrate/version.dart
@@ -1,7 +1,7 @@
 import 'package:codemod/codemod.dart';
 
 /// The lateste version of riverpod that migrated code should be updated to
-const latestVersion = '0.14.0';
+const latestVersion = '0.15.0';
 
 /// Migrates the pubspec to the [latestVersion]
 Stream<Patch> versionMigrationSuggestor(FileContext context) async* {

--- a/packages/riverpod_cli/lib/src/migrate/version.dart
+++ b/packages/riverpod_cli/lib/src/migrate/version.dart
@@ -1,7 +1,7 @@
 import 'package:codemod/codemod.dart';
 
 /// The lateste version of riverpod that migrated code should be updated to
-const latestVersion = '0.15.0';
+const latestVersion = '1.0.0-dev.1';
 
 /// Migrates the pubspec to the [latestVersion]
 Stream<Patch> versionMigrationSuggestor(FileContext context) async* {

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -1,20 +1,20 @@
 name: riverpod_cli
 description: A command line tool for Riverpod
-version: 0.0.2+2
+version: 0.0.3
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ">=0.37.0 <0.40.0"
-  args: ^1.5.0
-  codemod: ^0.3.1
-  glob: ^1.2.0
+  analyzer: "^1.5.0"
+  args: ^2.0.0
+  codemod: ^1.0.0
+  glob: ^2.0.1
   path: ^1.8.0
-  pub_semver: ^1.4.4
-  pubspec_parse: ^0.1.8
+  pub_semver: ^2.0.0
+  pubspec_parse: ^1.0.0
 
 dev_dependencies:
   dart_style: any

--- a/packages/riverpod_cli/test/goldens.dart
+++ b/packages/riverpod_cli/test/goldens.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:codemod/codemod.dart';
 import 'package:codemod/test.dart';

--- a/packages/riverpod_cli/test/notifiers_test.dart
+++ b/packages/riverpod_cli/test/notifiers_test.dart
@@ -24,7 +24,7 @@ void main() {
       );
     }
 
-    Future<void> testNotifierNoOp(
+    Future<void> testAlreadyMigrated(
       String type,
       VersionConstraint versionConstraint,
     ) async {
@@ -63,21 +63,21 @@ void main() {
 
     group('Already Migrated', () {
       test('ChangeNotifier', () async {
-        await testNotifierNoOp(
+        await testAlreadyMigrated(
           'change_notifier_provider',
           VersionConstraint.parse('^0.14.0'),
         );
       });
 
       test('StateNotifier', () async {
-        await testNotifierNoOp(
+        await testAlreadyMigrated(
           'state_notifier_provider',
           VersionConstraint.parse('^0.14.0'),
         );
       });
 
       test('StateProvider', () async {
-        await testNotifierNoOp(
+        await testAlreadyMigrated(
           'state_provider',
           VersionConstraint.parse('^0.14.0'),
         );

--- a/packages/riverpod_cli/test/unified_syntax_test.dart
+++ b/packages/riverpod_cli/test/unified_syntax_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:riverpod_cli/src/migrate/unified_syntax.dart';
+import 'package:test/test.dart';
+
+import 'goldens.dart';
+
+void main() {
+  group('Unified Syntax', () {
+    test('Migration', () async {
+      final sourceFile = await fileContextForInput(
+          './fixtures/unified_syntax/input/widgets.dart');
+      final expected = File('./fixtures/unified_syntax/golden/widgets.dart')
+          .readAsStringSync();
+
+      await expectSuggestorSequenceGeneratesFormattedPatches(
+        [
+          RiverpodHooksProviderInfo(
+            VersionConstraint.parse('^0.14.0'),
+          ),
+          RiverpodUnifiedSyntaxChangesMigrationSuggestor(
+            VersionConstraint.parse('^0.14.0'),
+          ),
+        ],
+        sourceFile,
+        expected,
+      );
+    });
+
+    test('Already Migrated', () async {
+      final sourceFile = await fileContextForInput(
+          './fixtures/unified_syntax/golden/widgets.dart');
+      final expected = File('./fixtures/unified_syntax/golden/widgets.dart')
+          .readAsStringSync();
+
+      await expectSuggestorSequenceGeneratesFormattedPatches(
+        [
+          RiverpodHooksProviderInfo(
+            VersionConstraint.parse('^1.0.0'),
+          ),
+          RiverpodUnifiedSyntaxChangesMigrationSuggestor(
+            VersionConstraint.parse('^1.0.0'),
+          ),
+        ],
+        sourceFile,
+        expected,
+      );
+    });
+  });
+}


### PR DESCRIPTION
@rrousselGit 

Let me know if anything major is missing. Here is a quick list of everything I've implemented and tested
- [x] Migrate cli tool to null-safety
- [x] ProviderReference -> ProviderRefBase variants
- [x] build method migration
- [x] ProviderListener extraction to top of build method using ref.listen (including getting rid of context parameter in the lambdas or a method / function tearoff).
- [x] didUpdateProvider migration
- [x] Add type parameters to all provider types
- [x] Fix some issues with nullability (no one reported an error, but found / fixed and added tests)
- [x] context.read / refresh -> ref.read / refresh
- [x] useProvider -> ref.watch
- [x] migrate hook functions that depend on providers (added as first parameter)
- [x] migrate Hook / HookBuilder widgets that depend on providers
- [x] migrate Stateful / Stateless widgets that use context.read / context.refresh in callbacks

Missing migration (let me know if any of these are high priority)
- [ ] Family.overrideWithProvider 
- [ ] ProviderContainer.debugProviderValues / ProviderContainer.debugProviderElements -> ProviderContainer.getAllProviderElements
