### PR TITLE
make the migrate command able to be debugged

### DIFF
--- a/packages/riverpod_cli/CHANGELOG.md
+++ b/packages/riverpod_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0-dev.4
+
+- Add codemod flags for migrate command
+
 # 1.0.0-dev.2
 
 - The migration now updates ScopedProvider => Provider

--- a/packages/riverpod_cli/lib/src/migrate.dart
+++ b/packages/riverpod_cli/lib/src/migrate.dart
@@ -12,6 +12,32 @@ import 'migrate/unified_syntax.dart';
 import 'migrate/version.dart';
 
 class MigrateCommand extends Command<void> {
+  MigrateCommand() {
+    argParser
+      ..addFlag(
+        'verbose',
+        abbr: 'v',
+        negatable: false,
+        help: 'Outputs all logging to stdout/stderr.',
+      )
+      ..addFlag(
+        'yes-to-all',
+        negatable: false,
+        help: 'Forces all patches accepted without prompting the user. '
+            'Useful for scripts.',
+      )
+      ..addFlag(
+        'fail-on-changes',
+        negatable: false,
+        help: 'Returns a non-zero exit code if there are changes to be made. '
+            'Will not make any changes (i.e. this is a dry-run).',
+      )
+      ..addFlag(
+        'stderr-assume-tty',
+        negatable: false,
+        help: 'Forces ansi color highlighting of stderr. Useful for debugging.',
+      );
+  }
   @override
   String get name => 'migrate';
 

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_cli
 description: A command line tool for Riverpod
-version: 1.0.0-dev.3
+version: 1.0.0-dev.4
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: "^1.5.0"
   args: ^2.0.0
-  codemod: ^1.0.0
+  codemod: ^1.0.1
   glob: ^2.0.1
   path: ^1.8.0
   pub_semver: ^2.0.0


### PR DESCRIPTION
@rrousselGit 
#607 Made me realize we don't currently parse the arguments needed for debugging the migration tool. This PR adds the flags that codemod accepts.