### PR TITLE
add overrideWithProvider to ProviderFamily

### DIFF
--- a/packages/riverpod/lib/src/provider/base.dart
+++ b/packages/riverpod/lib/src/provider/base.dart
@@ -294,4 +294,16 @@ class ProviderFamily<State, Arg> extends Family<State, Arg, Provider<State>> {
       name: name,
     );
   }
+
+  /// Overrides the behavior of a family for a part of the application.
+  ///
+  /// {@macro riverpod.overideWith}
+  Override overrideWithProvider(
+    ProviderBase<State> Function(Arg argument) override,
+  ) {
+    return FamilyOverride<Arg>(this, (arg, setup) {
+      final provider = call(arg);
+      setup(origin: provider, override: override(arg));
+    });
+  }
 }


### PR DESCRIPTION
- this allows to override any basic ProviderFamily in tests, similar to
  e.g. StreamProviderFamily
