### PR TITLE
Super minor typo fixes

### DIFF
--- a/website/docs/concepts/reading.mdx
+++ b/website/docs/concepts/reading.mdx
@@ -172,12 +172,12 @@ cause our widget to rebuild.
 
 ### context.read(myProvider)
 
-With [Consumer] and [ref.watch(], we've seen how to _listen_ to a provider.
+With [Consumer] and [ref.watch()], we've seen how to _listen_ to a provider.
 
 But in some situations, there's no value in listening to the object. For example,
 we may need the object only for the `onPressed` of a [RaisedButton].
 
-We _could_ use [ref.watch(]/[Consumer]:
+We _could_ use [ref.watch()]/[Consumer]:
 
 ```dart {2,4}
 Consumer(builder: (context, ref, _) {

--- a/website/docs/concepts/reading.mdx
+++ b/website/docs/concepts/reading.mdx
@@ -172,12 +172,12 @@ cause our widget to rebuild.
 
 ### context.read(myProvider)
 
-With [Consumer] and [ref.watch()], we've seen how to _listen_ to a provider.
+With [Consumer] and [ref.watch], we've seen how to _listen_ to a provider.
 
 But in some situations, there's no value in listening to the object. For example,
 we may need the object only for the `onPressed` of a [RaisedButton].
 
-We _could_ use [ref.watch()]/[Consumer]:
+We _could_ use [ref.watch]/[Consumer]:
 
 ```dart {2,4}
 Consumer(builder: (context, ref, _) {


### PR DESCRIPTION
Added two missing parentheses. `ref.watch(` -> `ref.watch()`