### PR TITLE
Add missing ref for HookConsumerWidget example on Getting Started

### DIFF
--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -143,7 +143,7 @@ void main() {
 // Note: MyApp is a HookConsumerWidget, from flutter_hooks.
 class MyApp extends HookConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     // To read our provider, we can use the hook "ref.watch(".
     // This is only possible because MyApp is a HookConsumerWidget.
     final String value = ref.watch(helloWorldProvider);


### PR DESCRIPTION
Thanks for the great library!
I found a typo and fixed it.

related issue: #629