### PR TITLE
Fixed an issue with dispose of ProviderElement created by override Provider in nested ProviderContainer

### DIFF
--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -510,20 +510,22 @@ class ProviderContainer {
     final visitedNodes = HashSet<ProviderElementBase>();
     final queue = DoubleLinkedQueue<ProviderElementBase>();
 
-    // get roots of the provider graph
+    // get providers that don't depend on other providers from this container
     for (final reader in _stateReaders.values) {
       if (reader.container != this) continue;
       final element = reader._element;
       if (element == null) continue;
 
-      var hasAncestors = false;
+      var hasAncestorsInContainer = false;
       element.visitAncestors((element) {
-        if(element._container == this) {
-          hasAncestors = true;
+        // We ignore dependencies that are defined in another container, as
+        // they are in a separate graph
+        if (element._container == this) {
+          hasAncestorsInContainer = true;
         }
       });
 
-      if (!hasAncestors) {
+      if (!hasAncestorsInContainer) {
         queue.add(element);
       }
     }

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -518,7 +518,9 @@ class ProviderContainer {
 
       var hasAncestors = false;
       element.visitAncestors((element) {
-        hasAncestors = true;
+        if(element._container == this) {
+          hasAncestors = true;
+        }
       });
 
       if (!hasAncestors) {

--- a/packages/riverpod/test/framework/provider_container_test.dart
+++ b/packages/riverpod/test/framework/provider_container_test.dart
@@ -55,6 +55,43 @@ void main() {
     });
 
     group('getAllProviderElements', () {
+      test('list scoped providers that depends on nothing', () {
+        final scopedProvider = Provider<int>((ref) => 0);
+        final parent = createContainer();
+        final child = createContainer(
+          parent: parent,
+          overrides: [scopedProvider],
+        );
+
+        child.read(scopedProvider);
+
+        expect(
+          child.getAllProviderElements().single,
+          isA<ProviderElement>()
+              .having((e) => e.origin, 'origin', scopedProvider),
+        );
+      });
+
+      test(
+          'list scoped providers that depends on providers from another container',
+          () {
+        final dependency = Provider((ref) => 0);
+        final scopedProvider = Provider<int>((ref) => ref.watch(dependency));
+        final parent = createContainer();
+        final child = createContainer(
+          parent: parent,
+          overrides: [scopedProvider],
+        );
+
+        child.read(scopedProvider);
+
+        expect(
+          child.getAllProviderElements().single,
+          isA<ProviderElement>()
+              .having((e) => e.origin, 'origin', scopedProvider),
+        );
+      });
+
       test(
           'list only elements associated with the container (ingoring inherited and descendent elements)',
           () {
@@ -121,23 +158,14 @@ void main() {
         );
       });
     });
-    
+
     group('getAllProviderElementsInOrder', () {
-      test(
-          'list elements of scoped provider override with provider that depends on other container',
-          () {
-        final provider = StateNotifierProvider<Counter, int>((ref) {
-          return Counter();
-        });
-        final scopedProvider = Provider<int>((ref) {
-          throw UnimplementedError();
-        });
+      test('list scoped providers that depends on nothing', () {
+        final scopedProvider = Provider<int>((ref) => 0);
         final parent = createContainer();
         final child = createContainer(
           parent: parent,
-          overrides: [
-            scopedProvider.overrideWithProvider(provider),
-          ],
+          overrides: [scopedProvider],
         );
 
         child.read(scopedProvider);
@@ -145,8 +173,27 @@ void main() {
         expect(
           child.getAllProviderElementsInOrder().single,
           isA<ProviderElement>()
-              .having((e) => e.origin, 'origin', scopedProvider)
-              .having((e) => e.provider, 'provider', provider),
+              .having((e) => e.origin, 'origin', scopedProvider),
+        );
+      });
+
+      test(
+          'list scoped providers that depends on providers from another container',
+          () {
+        final dependency = Provider((ref) => 0);
+        final scopedProvider = Provider<int>((ref) => ref.watch(dependency));
+        final parent = createContainer();
+        final child = createContainer(
+          parent: parent,
+          overrides: [scopedProvider],
+        );
+
+        child.read(scopedProvider);
+
+        expect(
+          child.getAllProviderElementsInOrder().single,
+          isA<ProviderElement>()
+              .having((e) => e.origin, 'origin', scopedProvider),
         );
       });
     });

--- a/packages/riverpod/test/framework/provider_container_test.dart
+++ b/packages/riverpod/test/framework/provider_container_test.dart
@@ -121,6 +121,35 @@ void main() {
         );
       });
     });
+    
+    group('getAllProviderElementsInOrder', () {
+      test(
+          'list elements of scoped provider override with provider that depends on other container',
+          () {
+        final provider = StateNotifierProvider<Counter, int>((ref) {
+          return Counter();
+        });
+        final scopedProvider = Provider<int>((ref) {
+          throw UnimplementedError();
+        });
+        final parent = createContainer();
+        final child = createContainer(
+          parent: parent,
+          overrides: [
+            scopedProvider.overrideWithProvider(provider),
+          ],
+        );
+
+        child.read(scopedProvider);
+
+        expect(
+          child.getAllProviderElementsInOrder().single,
+          isA<ProviderElement>()
+              .having((e) => e.origin, 'origin', scopedProvider)
+              .having((e) => e.provider, 'provider', provider),
+        );
+      });
+    });
 
     test(
         'does not re-initialize a provider if read by a child container after the provider was initialized',


### PR DESCRIPTION
Talk about #665

The ProviderElement created by the override Provider in the nested ProviderContainer is not properly disposed.
Fixed `getAllProviderElementsInOrder` function to correspond to nested ProviderContainer.
When checking ancestor of ProviderElement, don't flag hasAncestors if the ProviderContainer doesn't match.