### PR TITLE
docs: fix spelling

### DIFF
--- a/website/docs/concepts/providers.mdx
+++ b/website/docs/concepts/providers.mdx
@@ -4,7 +4,7 @@ title: Providers
 
 Now that we have installed [Riverpod], let's talk about "providers".
 
-Providers are the most important part of a [Riverpod] application.  
+Providers are the most important part of a [Riverpod] application.
 A provider is an object that encapsulate a piece of state and allows listening
 to that state.
 
@@ -12,19 +12,19 @@ to that state.
 
 By wrapping a piece of state in a provider, this:
 
-- Allows easily accessing that state in multiple locations.  
+- Allows easily accessing that state in multiple locations.
   Providers are a complete replacement for patterns like Singletons,
   Service Locators, Dependency Injection or InheritedWidgets.
 
-- Simplifies combining this state with others.  
+- Simplifies combining this state with others.
   Ever struggled merging multiple objects into one? This scenario is built
   directly inside providers, with a simple syntax.
 
-- Enables performance optimisations.  
+- Enables performance optmization.
   Whether for filtering widget rebuilds or for caching expensive state computations;
   providers ensure that only what is impacted by a state change is recomputed.
 
-- Increases the testability of your application.  
+- Increases the testability of your application.
   With providers, you do not need complex `setUp`/`tearDown` steps. Furthermore,
   any provider can be overridden to behave differently during test, which
   allows easily testing a very specific behavior.
@@ -44,35 +44,35 @@ final myProvider = Provider((ref) {
 ```
 
 :::note
-Do not be afraid by the global aspect of providers.  
+Do not be afraid by the global aspect of providers.
 Providers are fully immutable. Declaring a provider is no different from declaring
 a function, and is testable and maintainable.
 :::
 
 This snippet consists of three components:
 
-- `final myProvider`, the declaration of a variable.  
+- `final myProvider`, the declaration of a variable.
   This variable is what we will use in the future to read the state of our provider.
   It should always be immutable.
 
-- `Provider`, the provider that we decided to use.  
+- `Provider`, the provider that we decided to use.
   [Provider] is the most basic of all providers. It exposes an object that never
-  changes.  
+  changes.
   We could replace [Provider] with other providers like [StreamProvider] or
   [StateNotifierProvider], to change how the value is interacted with.
 
-- A function that creates the shared state.  
+- A function that creates the shared state.
   That function will always receive an object called `ref` as a parameter. This object
   allows us to read other providers or to perform some operations when the state
   of our provider will be destroyed.
 
 The type of the object created by the function passed to a provider depends on
-the provider used.  
+the provider used.
 For example, the function of a [Provider] can create any object.
 On the other hand, [StreamProvider]'s callback will be expected to return a [Stream].
 
 :::info
-You can declare as many providers as you want without limitations.  
+You can declare as many providers as you want without limitations.
 As opposed to when using `package:provider`, in [Riverpod] we can have two
 providers expose a state of the same "type":
 
@@ -120,7 +120,7 @@ final example = StreamProvider.autoDispose((ref) {
 ```
 
 :::note
-Depending on the provider used, it may already take care of the clean-up process.  
+Depending on the provider used, it may already take care of the clean-up process.
 For example, [StateNotifierProvider] will call the `dispose` method of a `StateNotifier`.
 :::
 
@@ -129,7 +129,7 @@ For example, [StateNotifierProvider] will call the `dispose` method of a `StateN
 All Providers have a built-in way to add extra functionalities to your different providers.
 
 They may add new features to the `ref` object or change slightly how the provider
-is consumed.  
+is consumed.
 Modifiers can be used on all providers, with a syntax similar to named constructor:
 
 ```dart


### PR DESCRIPTION
just fix spelling on document. and also trailing spaces by formatting. 