### PR TITLE
Delete unnecessary/harmful `deafult` case

### DIFF
--- a/examples/todos/lib/main.dart
+++ b/examples/todos/lib/main.dart
@@ -62,7 +62,6 @@ final filteredTodos = Provider<List<Todo>>((ref) {
     case TodoListFilter.active:
       return todos.where((todo) => !todo.completed).toList();
     case TodoListFilter.all:
-    default:
       return todos;
   }
 });


### PR DESCRIPTION
In the past, `default` clause was required, but after null safety was supported, it became unnecessary.