### PR TITLE
Fix listener migration & #937 exception

### DIFF
--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
@@ -180,6 +180,32 @@ class StatelessExpressionListen extends ConsumerWidget {
   }
 }
 
+class StatefulConsumerBasic extends ConsumerStatefulWidget {
+  const StatefulConsumerBasic({Key? key}) : super(key: key);
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _StatefulConsumerBasicState();
+}
+
+class _StatefulConsumerBasicState extends ConsumerState<StatefulConsumer> {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: GestureDetector(
+        onTap: () {
+          ref.read(counterProvider);
+        },
+        child: Consumer(
+          builder: (context, ref, child) {
+            return Text('${ref.watch(counterProvider)}');
+          },
+        ),
+      ),
+    );
+  }
+}
+
 class StatefulConsumer extends ConsumerStatefulWidget {
   const StatefulConsumer({Key? key}) : super(key: key);
 

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
@@ -208,11 +208,6 @@ class _StatefulConsumerBasicState extends ConsumerState<StatefulConsumerBasic> {
         onTap: () {
           ref.read(counterProvider);
         },
-        child: Consumer(
-          builder: (context, ref, child) {
-            return Text('${ref.watch(counterProvider)}');
-          },
-        ),
       ),
     );
   }

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/widgets.dart
@@ -145,7 +145,7 @@ class StatelessListen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen(counterProvider, (previous, i) {
+    ref.listen<int>(counterProvider, (previous, i) {
       print(i);
     });
     return const Text('Counter');
@@ -157,7 +157,19 @@ class StatelessListen2 extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen(counterProvider, _onChange);
+    ref.listen<int>(counterProvider, _onChange);
+    return const Text('Counter');
+  }
+}
+
+class StatelessListen3 extends ConsumerWidget {
+  const StatelessListen3({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<int>>(futureProvider, (previous, i) {
+      print(i);
+    });
     return const Text('Counter');
   }
 }
@@ -171,7 +183,7 @@ class StatelessExpressionListen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen(counterProvider, onChange);
+    ref.listen<int>(counterProvider, onChange);
     return const Text('Counter');
   }
 
@@ -188,7 +200,7 @@ class StatefulConsumerBasic extends ConsumerStatefulWidget {
       _StatefulConsumerBasicState();
 }
 
-class _StatefulConsumerBasicState extends ConsumerState<StatefulConsumer> {
+class _StatefulConsumerBasicState extends ConsumerState<StatefulConsumerBasic> {
   @override
   Widget build(BuildContext context) {
     return Center(

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
@@ -165,6 +165,21 @@ class StatelessListen2 extends StatelessWidget {
   }
 }
 
+class StatelessListen3 extends StatelessWidget {
+  const StatelessListen3({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderListener(
+      provider: futureProvider,
+      onChange: (context, i) {
+        print(i);
+      },
+      child: const Text('Counter'),
+    );
+  }
+}
+
 void _onChange(BuildContext context, int i) {
   print(i);
 }
@@ -191,7 +206,7 @@ class StatefulConsumerBasic extends StatefulWidget {
   State<StatefulWidget> createState() => _StatefulConsumerBasicState();
 }
 
-class _StatefulConsumerBasicState extends State<StatefulConsumer> {
+class _StatefulConsumerBasicState extends State<StatefulConsumerBasic> {
   @override
   Widget build(BuildContext context) {
     return Center(

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
@@ -184,6 +184,31 @@ class StatelessExpressionListen extends StatelessWidget {
   }
 }
 
+class StatefulConsumerBasic extends StatefulWidget {
+  const StatefulConsumerBasic({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _StatefulConsumerBasicState();
+}
+
+class _StatefulConsumerBasicState extends State<StatefulConsumer> {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: GestureDetector(
+        onTap: () {
+          context.read(counterProvider);
+        },
+        child: Consumer(
+          builder: (context, watch, child) {
+            return Text('${watch(counterProvider)}');
+          },
+        ),
+      ),
+    );
+  }
+}
+
 class StatefulConsumer extends StatefulWidget {
   const StatefulConsumer({Key? key}) : super(key: key);
 

--- a/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
+++ b/packages/riverpod_cli/fixtures/unified_syntax/input/widgets.dart
@@ -214,11 +214,6 @@ class _StatefulConsumerBasicState extends State<StatefulConsumerBasic> {
         onTap: () {
           context.read(counterProvider);
         },
-        child: Consumer(
-          builder: (context, watch, child) {
-            return Text('${watch(counterProvider)}');
-          },
-        ),
       ),
     );
   }

--- a/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
+++ b/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
@@ -411,7 +411,8 @@ class RiverpodUnifiedSyntaxChangesMigrationSuggestor
           .split(',');
 
       var listenType = types.length > 1 ? types[1] : types[0];
-      if (providerType.contains('Future') || providerType.contains('Stream')) {
+      if (providerType.contains('FutureProvider') ||
+          providerType.contains('StreamProvider')) {
         listenType = 'AsyncValue<$listenType>';
       }
 

--- a/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
+++ b/packages/riverpod_cli/lib/src/migrate/unified_syntax.dart
@@ -1,6 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart';

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
 dev_dependencies:
   dart_style: any
   test: any
+  diff_match_patch: ^0.4.1
 
 executables:
   riverpod: riverpod_cli

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   analyzer: "^1.5.0"
   args: ^2.0.0
   codemod: ^1.0.1
+  collection: ^1.15.0
   glob: ^2.0.1
   meta: ^1.7.0
   path: ^1.8.0

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
 dev_dependencies:
   dart_style: any
   test: any
-  diff_match_patch: ^0.4.1
 
 executables:
   riverpod: riverpod_cli

--- a/packages/riverpod_cli/test/goldens.dart
+++ b/packages/riverpod_cli/test/goldens.dart
@@ -4,8 +4,6 @@ import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:codemod/codemod.dart';
 import 'package:codemod/test.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:diff_match_patch/diff_match_patch.dart'
-    show DiffMatchPatch, patchToText;
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 


### PR DESCRIPTION
Adds type parameters when migrating `ProviderListener` to `ref.listen`

Checks for null to prevent #937 exception

Improves test output to contain diff when tests fail, so it is easier to develop the migration code.

@rrousselGit Can you take a look at this when you have time?

@creativecreatorormaybenot Not sure if this will fix your problem of not finding anything to migrate, but it does get rid of the exception you saw in #937
