### PR TITLE
Removed .state from filter from eng and fr

### DIFF
--- a/website/docs/concepts/combining_providers.mdx
+++ b/website/docs/concepts/combining_providers.mdx
@@ -82,7 +82,7 @@ An easy way to implement such scenario would be to:
     final filter = ref.watch(filterProvider);
     final todos = ref.watch(todoListProvider);
 
-    switch (filter.state) {
+    switch (filter) {
       case Filter.none:
         return todos;
       case Filter.completed:

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -6,10 +6,10 @@ Avant de commencer, assurez-vous de lire la section sur [les providers](/docs/co
 
 ### Combiner des providers
 
-Nous avons vu précédemment comment créer un simple provider. Mais la réalité est la suivante, 
+Nous avons vu précédemment comment créer un simple provider. Mais la réalité est la suivante,
 dans de nombreuses situations, un provider pourra vouloir lire l'état d'un autre provider.
 
-Pour ce faire, nous pouvons utiliser l'objet [ref] passé au 
+Pour ce faire, nous pouvons utiliser l'objet [ref] passé au
 callback de notre provider, et utiliser sa méthode [watch].
 
 À titre d'exemple, considérons le provider suivant :
@@ -22,12 +22,12 @@ Nous pouvons maintenant créer un autre provider qui va consommer notre `cityPro
 
 ```dart
 final weatherProvider = FutureProvider((ref) async {
-  // On utilise `ref.watch` pour écouter un autre provider, 
-  // et on lui passe le provider que l'on veut consommer. 
+  // On utilise `ref.watch` pour écouter un autre provider,
+  // et on lui passe le provider que l'on veut consommer.
   // Ici : cityProvider
   final city = ref.watch(cityProvider);
 
-  // On peut ensuite utiliser le résultat pour faire quelque chose en 
+  // On peut ensuite utiliser le résultat pour faire quelque chose en
   // fonction de la valeur de `cityProvider`.
   return fetchWeather(city: city);
 });
@@ -39,12 +39,12 @@ Et voilà. Nous avons créé un provider qui dépend d'un autre provider.
 
 ### Que faire si la valeur écoutée change au fil du temps ? Et voilà. Nous avons créé un provider qui dépend d'un autre provider.
 
-Selon le provider que vous écoutez, la valeur obtenue peut changer au fil du temps. 
+Selon le provider que vous écoutez, la valeur obtenue peut changer au fil du temps.
 
-Par exemple, vous pourriez être à l'écoute d'un [StateNotifierProvider], 
+Par exemple, vous pourriez être à l'écoute d'un [StateNotifierProvider],
 ou le provider écouté a été forcé de se rafraîchir à l'aide de [ProviderContainer.refresh]/[ref.refresh].
 
-En utilisant [watch], Riverpod est capable de détecter que la valeur 
+En utilisant [watch], Riverpod est capable de détecter que la valeur
 écoutée a changé et réexécutera _automatiquement_ le provider si nécessaire.
 
 Cela peut être utile pour les états (states) calculés.
@@ -57,23 +57,25 @@ class TodoList extends StateNotifier<List<Todo>> {
 
 final todoListProvider = StateNotifierProvider((ref) => TodoList());
 ```
-Un cas d'utilisation commun serait de faire en sorte que l'interface utilisateur (UI) filtre la liste des tâches (todos) 
+
+Un cas d'utilisation commun serait de faire en sorte que l'interface utilisateur (UI) filtre la liste des tâches (todos)
 pour n'afficher seulement les tâches terminées/non terminées.
 
 Une façon simple de mettre en place un tel scénario serait de :
 
 - créer [StateProvider], qui présente la méthode de filtrage actuellement sélectionnée :
 
- ```dart
-  enum Filter {
-    none,
-    completed,
-    uncompleted,
-  }
+```dart
+ enum Filter {
+   none,
+   completed,
+   uncompleted,
+ }
 
-  final filterProvider = StateProvider((ref) => Filter.none);
-  ```
-- créer un provider indépendant qui combine la méthode de filtrage et 
+ final filterProvider = StateProvider((ref) => Filter.none);
+```
+
+- créer un provider indépendant qui combine la méthode de filtrage et
   la todo-list pour exposer la todo-list filtrée :
 
   ```dart
@@ -92,18 +94,18 @@ Une façon simple de mettre en place un tel scénario serait de :
   });
   ```
 
-Ensuite, notre interface utilisateur (UI) peut écouter `filteredTodoListProvider` pour écouter la todo-list filtrée. 
-En utilisant cette approche, l'interface sera automatiquement mise à jour lorsque le filtre ou 
+Ensuite, notre interface utilisateur (UI) peut écouter `filteredTodoListProvider` pour écouter la todo-list filtrée.
+En utilisant cette approche, l'interface sera automatiquement mise à jour lorsque le filtre ou
 la liste de tâches changera. ou la todo-list change.
 
-Pour voir cette approche en action, vous pouvez consulter le code source de 
+Pour voir cette approche en action, vous pouvez consulter le code source de
 [exemple de Todo List](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
 
 :::info
 Ce comportement n'est pas spécifique à [Provider], et fonctionne avec tous les providers.
 
-Par exemple, vous pouvez combiner [watch] et [FutureProvider] pour implémenter une fonction de recherche 
-ou un mode de changement de live-configuration. 
+Par exemple, vous pouvez combiner [watch] et [FutureProvider] pour implémenter une fonction de recherche
+ou un mode de changement de live-configuration.
 
 ```dart
 // Le filtre de recherche actuel
@@ -121,25 +123,25 @@ final charactersProvider = FutureProvider<List<Character>>((ref) async {
 });
 ```
 
-Ce code récupère une liste de caractères à partir du service, 
-et récupère à nouveau automatiquement la liste, chaque fois que les 
+Ce code récupère une liste de caractères à partir du service,
+et récupère à nouveau automatiquement la liste, chaque fois que les
 configurations changent ou que la requête de recherche change.
 :::
 
 ### Peut-on lire un provider sans l'écouter ?
 
-Parfois, on souhaite lire le contenu d'un provider, mais sans recréer la valeur 
+Parfois, on souhaite lire le contenu d'un provider, mais sans recréer la valeur
 exposée lorsque la valeur obtenue change.
 
 Un exemple serait un `Repository`, qui lit depuis un autre provider le jeton de l'utilisateur
 pour l'authentification.
-Nous pourrions utiliser [watch] et créer un nouveau `Repository` chaque fois que le jeton de l'utilisateur change, 
+Nous pourrions utiliser [watch] et créer un nouveau `Repository` chaque fois que le jeton de l'utilisateur change,
 mais il y a peu ou pas d'utilité à faire cela.
 
-Dans cette situation, nous pouvons utiliser [read], qui est similaire à [watch], mais qui n'obligera pas le provider 
+Dans cette situation, nous pouvons utiliser [read], qui est similaire à [watch], mais qui n'obligera pas le provider
 à recréer sa valeur exposée lorsque la valeur obtenue change.
 
-Dans ce cas, une pratique commune est de faire passer `ref.read` à l'objet créé. 
+Dans ce cas, une pratique commune est de faire passer `ref.read` à l'objet créé.
 Cet objet sera alors capable de lire les providers quand il le souhaite.
 
 ```dart
@@ -150,7 +152,7 @@ final repositoryProvider = Provider((ref) => Repository(ref.read));
 class Repository {
   Repository(this.read);
 
-  /// La fonction `ref.read` 
+  /// La fonction `ref.read`
   final Reader read;
 
   Future<Catalog> fetchCatalog() async {
@@ -178,7 +180,7 @@ class Repository {
 }
 ```
 
-La seule différence que le passage de `ref.read` apporte est un code 
+La seule différence que le passage de `ref.read` apporte est un code
 un peu moins verbeux et la garantie que notre objet n'utilise jamais `ref.watch`.
 :::
 
@@ -191,17 +193,17 @@ final myProvider = Provider((ref) {
 });
 ```
 
-Si vous avez utilisé [read] pour tenter d'éviter les reconstructions non souhaitées de votre objet, reportez-vous à 
+Si vous avez utilisé [read] pour tenter d'éviter les reconstructions non souhaitées de votre objet, reportez-vous à
 [Mon provider fait des mises à jour trop souvent, que puis-je faire ?](#mon-provider-fait-des-mises-à-jour-trop-souvent-que-puis-je-faire-)
 Mauvaise pratique pour appeler `read` ici
 :::
 
 ### Comment tester un objet qui reçoit [read] comme paramètre de son constructeur ?
 
-Si vous utilisez le modèle décrit dans [Peut-on lire un provider sans l'écouter ?](#peut-on-lire-un-provider-sans-lécouter-), 
+Si vous utilisez le modèle décrit dans [Peut-on lire un provider sans l'écouter ?](#peut-on-lire-un-provider-sans-lécouter-),
 vous vous demandez peut-être comment écrire des tests pour votre objet.
 
-Dans ce scénario, considérez tester le provider directement au lieu de l'objet brut. 
+Dans ce scénario, considérez tester le provider directement au lieu de l'objet brut.
 Vous pouvez le faire en utilisant la classe [ProviderContainer] :
 
 ```dart
@@ -222,15 +224,15 @@ test('fetches catalog', () async {
 
 ### Mon provider fait des mises à jour trop souvent, que puis-je faire ?
 
-Si votre objet est recréé trop souvent, il y a de fortes chances que votre provider soit en train 
+Si votre objet est recréé trop souvent, il y a de fortes chances que votre provider soit en train
 d'écouter des objets dont il ne se soucie pas.
 
-Par exemple, vous pouvez écouter un objet `Configuration`, 
+Par exemple, vous pouvez écouter un objet `Configuration`,
 mais n'utiliser que sa propriété `host`.
-En écoutant l'ensemble de l'objet `Configuration`, si une propriété 
+En écoutant l'ensemble de l'objet `Configuration`, si une propriété
 autre que `host` est modifiée, votre provider sera toujours réévalué. Ce qui peut être indésirable.
 
-La solution à ce problème est de créer un provider séparé qui expose _seulement_ ce dont vous 
+La solution à ce problème est de créer un provider séparé qui expose _seulement_ ce dont vous
 avez besoin dans `Configuration` (donc `host`).
 
 **ÉVITEZ** l'écoute de l'objet entier :
@@ -239,7 +241,7 @@ avez besoin dans `Configuration` (donc `host`).
 final configsProvider = StreamProvider<Configuration>(...);
 
 final productsProvider = FutureProvider<List<Product>>((ref) async {
-  // Le ProductsProvider devra récupérer les produits si 
+  // Le ProductsProvider devra récupérer les produits si
   // un élément de la configuration change.
   final configs = await ref.watch(configsProvider.last);
 
@@ -259,7 +261,7 @@ final _hostProvider = FutureProvider<String>((ref) async {
 });
 
 final productsProvider = FutureProvider<List<Product>>((ref) async {
-  // Écoute uniquement le host. Si quelque chose d'autre dans les configurations change, 
+  // Écoute uniquement le host. Si quelque chose d'autre dans les configurations change,
   // cela ne réévaluera pas inutilement notre provider.
   final host = await ref.watch(_hostProvider.future);
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -81,7 +81,7 @@ Une façon simple de mettre en place un tel scénario serait de :
     final filter = ref.watch(filterProvider);
     final todos = ref.watch(todoListProvider);
 
-    switch (filter.state) {
+    switch (filter) {
       case Filter.none:
         return todos;
       case Filter.completed:

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -6,10 +6,10 @@ Avant de commencer, assurez-vous de lire la section sur [les providers](/docs/co
 
 ### Combiner des providers
 
-Nous avons vu précédemment comment créer un simple provider. Mais la réalité est la suivante,
+Nous avons vu précédemment comment créer un simple provider. Mais la réalité est la suivante, 
 dans de nombreuses situations, un provider pourra vouloir lire l'état d'un autre provider.
 
-Pour ce faire, nous pouvons utiliser l'objet [ref] passé au
+Pour ce faire, nous pouvons utiliser l'objet [ref] passé au 
 callback de notre provider, et utiliser sa méthode [watch].
 
 À titre d'exemple, considérons le provider suivant :
@@ -22,12 +22,12 @@ Nous pouvons maintenant créer un autre provider qui va consommer notre `cityPro
 
 ```dart
 final weatherProvider = FutureProvider((ref) async {
-  // On utilise `ref.watch` pour écouter un autre provider,
-  // et on lui passe le provider que l'on veut consommer.
+  // On utilise `ref.watch` pour écouter un autre provider, 
+  // et on lui passe le provider que l'on veut consommer. 
   // Ici : cityProvider
   final city = ref.watch(cityProvider);
 
-  // On peut ensuite utiliser le résultat pour faire quelque chose en
+  // On peut ensuite utiliser le résultat pour faire quelque chose en 
   // fonction de la valeur de `cityProvider`.
   return fetchWeather(city: city);
 });
@@ -39,12 +39,12 @@ Et voilà. Nous avons créé un provider qui dépend d'un autre provider.
 
 ### Que faire si la valeur écoutée change au fil du temps ? Et voilà. Nous avons créé un provider qui dépend d'un autre provider.
 
-Selon le provider que vous écoutez, la valeur obtenue peut changer au fil du temps.
+Selon le provider que vous écoutez, la valeur obtenue peut changer au fil du temps. 
 
-Par exemple, vous pourriez être à l'écoute d'un [StateNotifierProvider],
+Par exemple, vous pourriez être à l'écoute d'un [StateNotifierProvider], 
 ou le provider écouté a été forcé de se rafraîchir à l'aide de [ProviderContainer.refresh]/[ref.refresh].
 
-En utilisant [watch], Riverpod est capable de détecter que la valeur
+En utilisant [watch], Riverpod est capable de détecter que la valeur 
 écoutée a changé et réexécutera _automatiquement_ le provider si nécessaire.
 
 Cela peut être utile pour les états (states) calculés.
@@ -57,25 +57,23 @@ class TodoList extends StateNotifier<List<Todo>> {
 
 final todoListProvider = StateNotifierProvider((ref) => TodoList());
 ```
-
-Un cas d'utilisation commun serait de faire en sorte que l'interface utilisateur (UI) filtre la liste des tâches (todos)
+Un cas d'utilisation commun serait de faire en sorte que l'interface utilisateur (UI) filtre la liste des tâches (todos) 
 pour n'afficher seulement les tâches terminées/non terminées.
 
 Une façon simple de mettre en place un tel scénario serait de :
 
 - créer [StateProvider], qui présente la méthode de filtrage actuellement sélectionnée :
 
-```dart
- enum Filter {
-   none,
-   completed,
-   uncompleted,
- }
+ ```dart
+  enum Filter {
+    none,
+    completed,
+    uncompleted,
+  }
 
- final filterProvider = StateProvider((ref) => Filter.none);
-```
-
-- créer un provider indépendant qui combine la méthode de filtrage et
+  final filterProvider = StateProvider((ref) => Filter.none);
+  ```
+- créer un provider indépendant qui combine la méthode de filtrage et 
   la todo-list pour exposer la todo-list filtrée :
 
   ```dart
@@ -94,18 +92,18 @@ Une façon simple de mettre en place un tel scénario serait de :
   });
   ```
 
-Ensuite, notre interface utilisateur (UI) peut écouter `filteredTodoListProvider` pour écouter la todo-list filtrée.
-En utilisant cette approche, l'interface sera automatiquement mise à jour lorsque le filtre ou
+Ensuite, notre interface utilisateur (UI) peut écouter `filteredTodoListProvider` pour écouter la todo-list filtrée. 
+En utilisant cette approche, l'interface sera automatiquement mise à jour lorsque le filtre ou 
 la liste de tâches changera. ou la todo-list change.
 
-Pour voir cette approche en action, vous pouvez consulter le code source de
+Pour voir cette approche en action, vous pouvez consulter le code source de 
 [exemple de Todo List](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
 
 :::info
 Ce comportement n'est pas spécifique à [Provider], et fonctionne avec tous les providers.
 
-Par exemple, vous pouvez combiner [watch] et [FutureProvider] pour implémenter une fonction de recherche
-ou un mode de changement de live-configuration.
+Par exemple, vous pouvez combiner [watch] et [FutureProvider] pour implémenter une fonction de recherche 
+ou un mode de changement de live-configuration. 
 
 ```dart
 // Le filtre de recherche actuel
@@ -123,25 +121,25 @@ final charactersProvider = FutureProvider<List<Character>>((ref) async {
 });
 ```
 
-Ce code récupère une liste de caractères à partir du service,
-et récupère à nouveau automatiquement la liste, chaque fois que les
+Ce code récupère une liste de caractères à partir du service, 
+et récupère à nouveau automatiquement la liste, chaque fois que les 
 configurations changent ou que la requête de recherche change.
 :::
 
 ### Peut-on lire un provider sans l'écouter ?
 
-Parfois, on souhaite lire le contenu d'un provider, mais sans recréer la valeur
+Parfois, on souhaite lire le contenu d'un provider, mais sans recréer la valeur 
 exposée lorsque la valeur obtenue change.
 
 Un exemple serait un `Repository`, qui lit depuis un autre provider le jeton de l'utilisateur
 pour l'authentification.
-Nous pourrions utiliser [watch] et créer un nouveau `Repository` chaque fois que le jeton de l'utilisateur change,
+Nous pourrions utiliser [watch] et créer un nouveau `Repository` chaque fois que le jeton de l'utilisateur change, 
 mais il y a peu ou pas d'utilité à faire cela.
 
-Dans cette situation, nous pouvons utiliser [read], qui est similaire à [watch], mais qui n'obligera pas le provider
+Dans cette situation, nous pouvons utiliser [read], qui est similaire à [watch], mais qui n'obligera pas le provider 
 à recréer sa valeur exposée lorsque la valeur obtenue change.
 
-Dans ce cas, une pratique commune est de faire passer `ref.read` à l'objet créé.
+Dans ce cas, une pratique commune est de faire passer `ref.read` à l'objet créé. 
 Cet objet sera alors capable de lire les providers quand il le souhaite.
 
 ```dart
@@ -152,11 +150,11 @@ final repositoryProvider = Provider((ref) => Repository(ref.read));
 class Repository {
   Repository(this.read);
 
-  /// La fonction `ref.read`
+  /// La fonction `ref.read` 
   final Reader read;
 
   Future<Catalog> fetchCatalog() async {
-    String token = read(userTokenProvider).state;
+    String token = read(userTokenProvider);
 
     final response = await dio.get('/path', queryParameters: {
       'token': token,
@@ -180,7 +178,7 @@ class Repository {
 }
 ```
 
-La seule différence que le passage de `ref.read` apporte est un code
+La seule différence que le passage de `ref.read` apporte est un code 
 un peu moins verbeux et la garantie que notre objet n'utilise jamais `ref.watch`.
 :::
 
@@ -193,17 +191,17 @@ final myProvider = Provider((ref) {
 });
 ```
 
-Si vous avez utilisé [read] pour tenter d'éviter les reconstructions non souhaitées de votre objet, reportez-vous à
+Si vous avez utilisé [read] pour tenter d'éviter les reconstructions non souhaitées de votre objet, reportez-vous à 
 [Mon provider fait des mises à jour trop souvent, que puis-je faire ?](#mon-provider-fait-des-mises-à-jour-trop-souvent-que-puis-je-faire-)
 Mauvaise pratique pour appeler `read` ici
 :::
 
 ### Comment tester un objet qui reçoit [read] comme paramètre de son constructeur ?
 
-Si vous utilisez le modèle décrit dans [Peut-on lire un provider sans l'écouter ?](#peut-on-lire-un-provider-sans-lécouter-),
+Si vous utilisez le modèle décrit dans [Peut-on lire un provider sans l'écouter ?](#peut-on-lire-un-provider-sans-lécouter-), 
 vous vous demandez peut-être comment écrire des tests pour votre objet.
 
-Dans ce scénario, considérez tester le provider directement au lieu de l'objet brut.
+Dans ce scénario, considérez tester le provider directement au lieu de l'objet brut. 
 Vous pouvez le faire en utilisant la classe [ProviderContainer] :
 
 ```dart
@@ -224,15 +222,15 @@ test('fetches catalog', () async {
 
 ### Mon provider fait des mises à jour trop souvent, que puis-je faire ?
 
-Si votre objet est recréé trop souvent, il y a de fortes chances que votre provider soit en train
+Si votre objet est recréé trop souvent, il y a de fortes chances que votre provider soit en train 
 d'écouter des objets dont il ne se soucie pas.
 
-Par exemple, vous pouvez écouter un objet `Configuration`,
+Par exemple, vous pouvez écouter un objet `Configuration`, 
 mais n'utiliser que sa propriété `host`.
-En écoutant l'ensemble de l'objet `Configuration`, si une propriété
+En écoutant l'ensemble de l'objet `Configuration`, si une propriété 
 autre que `host` est modifiée, votre provider sera toujours réévalué. Ce qui peut être indésirable.
 
-La solution à ce problème est de créer un provider séparé qui expose _seulement_ ce dont vous
+La solution à ce problème est de créer un provider séparé qui expose _seulement_ ce dont vous 
 avez besoin dans `Configuration` (donc `host`).
 
 **ÉVITEZ** l'écoute de l'objet entier :
@@ -241,7 +239,7 @@ avez besoin dans `Configuration` (donc `host`).
 final configsProvider = StreamProvider<Configuration>(...);
 
 final productsProvider = FutureProvider<List<Product>>((ref) async {
-  // Le ProductsProvider devra récupérer les produits si
+  // Le ProductsProvider devra récupérer les produits si 
   // un élément de la configuration change.
   final configs = await ref.watch(configsProvider.last);
 
@@ -261,7 +259,7 @@ final _hostProvider = FutureProvider<String>((ref) async {
 });
 
 final productsProvider = FutureProvider<List<Product>>((ref) async {
-  // Écoute uniquement le host. Si quelque chose d'autre dans les configurations change,
+  // Écoute uniquement le host. Si quelque chose d'autre dans les configurations change, 
   // cela ne réévaluera pas inutilement notre provider.
   final host = await ref.watch(_hostProvider.future);
 

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -1,0 +1,176 @@
+---
+title: I Provider
+---
+
+
+Ora che abbiamo installato [Riverpod], parliamo dei "provider".
+
+I Provider sono la parte più importante di un'applicazione [Riverpod].
+Un provider è un oggetto che incapsula un pezzo di stato e ci permette di ascoltare tale stato.
+
+
+## Perchè usare i provider?
+
+Avvolgendo un pezzo di stato in un provider, ciò:
+
+- Permette l'accesso a tale stato facilmente ed in posizioni differenti.
+  I Provider sono un rimpiazzamento completo a Design Patterns come Singleton, 
+  Service Locators, Dependency Injection o InheritedWidgets
+
+- Semplifica la combinazione di questo stato con altri.
+  Hai mai avuto difficolta nel combinare più oggetti in uno? Questo scenario è costruito
+  direttamente all'interno dei provider, con una sintassi semplice.
+
+- Permette ottimizzazioni delle performance.
+  Sia per filtrare la ricostruzione di più widget o per chaching di uno stato che richiede molta computazione;
+  I provider assicurano che solo ciò che è impattato dal cambio dello stato venga ricalcolato.
+
+- Incremento della testabilità della tua applicazione.
+  Con I provider, non hai più bisogno di complessi `setUp`/`tearDown`. Inoltre,
+  ogni provider può essere sovrascritto per comportarsi in maniera differente durante i test, che 
+  permettono di testare un comportamento specifico.
+
+- Integrazione facile di feature avanzate, come logging e transcina per aggiornare
+
+
+## Creare un provider
+
+I Provider si presentano in diverse varianti, ma funzionano tutti allo stesso modo.
+
+L'utilizzo più comune è quello di dichiararli come una costante globale:
+
+```dart
+final myProvider = Provider((ref) {
+  return MyValue();
+});
+```
+
+:::nota
+Non avere paura di definirli globalmente.
+I Provider sono totalmente immutabili. Dichiarare un provider non è differente dal dichiarare
+una funzione, inoltre è testabile e mantenibile.
+:::
+
+Questa porzione di codice consiste in 3 parti:
+
+- `final myProvider`, la declarazione della variabile.
+  Questa variabile è ciò che useremo in futuro per leggere lo stato del nostro provider.
+  Dovrebbe essere sempre immutabile.
+
+- `Provider`, il tipo di provider che decidiamo di utilizzare.
+  [Provider] è il più semplice tra i provider. Espone un oggetto che non cambia mai.  
+  Potremmo rimpiazzare [Provider] con altri provider come [StreamProvider] o
+  [StateNotifierProvider], per cambiare il modo in cui ci si interagisce.
+
+- Una funzione che create lo stato condiviso
+  Tale funzione ci permetterà di ricevere un oggetto chiamato `ref` come parametro. Questo oggetto
+  ci permette di leggere altri provider o fare alcune operazioni quando lo stato 
+  del nostro provider verrà distrutto.
+
+Il tipo di oggetto creato dalla funzione passata al provider dipende 
+dal provider utilizzato.
+Per esempio, la funzione di un [Provider] può creare qualsiasi oggetto.
+D'altra parte, con la callback di [StreamProvider] ci si aspetta che ritorni uno [Stream].
+
+:::info
+Puoi dichiarare quanti provider vuoi senza nessun limite.
+Contrariamente a quando si usa `package:provider`, con [Riverpod] possiamo avere due
+provider che espongono uno stato dello stesso "tipo":
+
+```dart
+final cityProvider = Provider((ref) => 'London');
+final countryProvider = Provider((ref) => 'England');
+```
+
+Il fatto che entrambi i provider create una `String` non causa nessun problema.
+:::
+
+:::attenzione
+Per permettere ai provider di funzionare, sei obbligato [ProviderScope] 
+nella radice della tua applicazione Flutter:
+
+```dart
+void main() {
+  runApp(ProviderScope(child: MyApp()));
+}
+```
+
+:::
+
+## Fare azioni prima della distruzione dello stato
+
+In alcuni casi, lo stato di un provider potrebbe essere distrutto o ricreato.
+Uno scenario comune in quelle situaizoni è quello di fare un clean-up (pulire) prima che lo stato di un provider
+è distrutto, come la chiusura di uno `StreamController`.
+
+Ciò è possibile utilizzando l'oggetto `ref`, che è passato nella callback di tutti i provider, 
+usando il suo metodo [onDispose].
+
+Il seguente esempio utilizza [onDispose] per chiudere uno `StreamController`:
+
+```dart
+final example = StreamProvider.autoDispose((ref) {
+  final streamController = StreamController<int>();
+
+  ref.onDispose(() {
+    // Chiude lo StreamController quando lo stato di questo provider è distrutto.
+    streamController.close();
+  });
+
+  return streamController.stream;
+});
+```
+
+:::nota
+In base al provider utilizzato, potrebbe prendersi cura del processo di clean-up.
+Per esempio, [StateNotifierProvider] chiamerà il metodo `dispose` dello `StateNotifier`
+:::
+
+## I Modificatori del Provider
+
+Tutti i provider hanno una modalità integrata per aggiungere funzionalità in più nei differenti provider.
+
+Potrebbero aggiungere nuove funzionalità all'oggetto `ref` o cambiare leggermente come il provider 
+è utilizzato.
+
+I modificatori possono essere utilizzati in tutti i provider, con una sintassi simile a un named constructor:
+
+```dart
+final myAutoDisposeProvider = StateProvider.autoDispose<int>((ref) => 0);
+final myFamilyProvider = Provider.family<String, int>((ref, id) => '$id');
+```
+
+Per il momento, ci sono due modificatori presenti:
+
+
+- [`.autoDispose`](/docs/concepts/modifiers/auto_dispose), che farà distruggere automaticamente lo stato del provider 
+  quando non + più in ascolto.
+- [`.family`](/docs/concepts/modifiers/family), che permetterà di creare un provide da parametri esterni.
+
+:::nota
+Un provider può utilizzare più modificatori in una sola volta:
+```dart
+final userProvider = FutureProvider.autoDispose.family<User, int>((ref, userId) async {
+  return fetchUser(userId);
+});
+```
+
+:::
+
+Questo è tutto per questa guida!
+
+Puoi andare avanti con [Come leggere un provider](/docs/concepts/reading).
+In alternativa, puoi vedere [Come combinare i provider](/docs/concepts/combining_providers).
+
+[get_it]: http://pub.dev/packages/get_it
+[inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
+[stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
+[ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
+[riverpod]: https://github.com/rrousselgit/river_pod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[provider]: https://pub.dev/documentation/riverpod/latest/riverpod/Provider-class.html
+[streamprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StreamProvider-class.html
+[statenotifierprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateNotifierProvider-class.html
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html


### PR DESCRIPTION
I'am really sorry 😅 when I've made the change on the french language prettier on save have formatted everything and removed white spaces, let me know if I have to restore it to the previous version thanks.