### PR TITLE
Typo et clarification autour de ProviderContainer

### DIFF
--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -29,8 +29,8 @@ Après tout, des variables globales pourraient rendre les tests difficile à
 Mais dans les faits: Certes les providers sont déclarés en tant que globales, mais
 leur état n'est quant-à lui pas global.
 
-À la place, il est stocké dans un objet namé [ProviderContainer], que vous avez
-sûrement si vous avez lû les exemple de code écrit avec dart exclusivement.  
+À la place, il est stocké dans un objet nommé [ProviderContainer], que vous avez
+sûrement déjà vu si vous avez lû les exemples de code précédents.  
 Dans le cas contraire, sachez que ce [ProviderContainer] est implicitement crée
 par [ProviderScope], le widget qui permet d'utiliser [Riverpod] dans une application Flutter.
 


### PR DESCRIPTION
Tentative de clarification du paragraphe.
Est ce que la partie qui fait référence à 'Dart exclusivement' est nécessaire?