### PR TITLE
Avoid double rebuilding of TodoItem

### DIFF
--- a/examples/todos/lib/main.dart
+++ b/examples/todos/lib/main.dart
@@ -236,10 +236,12 @@ class TodoItem extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Create a dummy notifier to make the widget rebuild on purpose
+    final dummy = useValueNotifier(false);
+    useListenable(dummy);
+
     final todo = ref.watch(_currentTodo);
     final itemFocusNode = useFocusNode();
-    // listen to focus chances
-    useListenable(itemFocusNode);
     final isFocused = itemFocusNode.hasFocus;
 
     final textEditingController = useTextEditingController();
@@ -254,6 +256,8 @@ class TodoItem extends HookConsumerWidget {
           if (focused) {
             textEditingController.text = todo.description;
           } else {
+            // Actually we don't need this, but put it here in case of removing the below committing changes
+            dummy.value ^= true;
             // Commit changes only when the textfield is unfocused, for performance
             ref
                 .read(todoListProvider.notifier)
@@ -264,6 +268,8 @@ class TodoItem extends HookConsumerWidget {
           onTap: () {
             itemFocusNode.requestFocus();
             textFieldFocusNode.requestFocus();
+            // Make the widget rebuild
+            dummy.value ^= true;
           },
           leading: Checkbox(
             value: todo.completed,


### PR DESCRIPTION
Actually, it is not an efficient solution, but it resolves the issue. Is there any method that can notify the widget to rebuild instead of using a dummy ValueNotifier?
https://github.com/rrousselGit/river_pod/issues/1030#issuecomment-1003361331