### PR TITLE
Fix typo in observer docs

### DIFF
--- a/website/docs/concepts/provider_observer.mdx
+++ b/website/docs/concepts/provider_observer.mdx
@@ -10,7 +10,7 @@ import { trimSnippet } from "../../src/components/CodeSnippet";
 
 To use it, extend the class ProviderObserver and override the method you like to use.
 
-[ProviderObserver] has four methods :
+[ProviderObserver] has three methods :
 
 - `didAddProvider` is called every time a provider was initialized, and the value exposed is value.
 - `didDisposeProvider` is called every time A provider was disposed


### PR DESCRIPTION
Just a simple typo fix in the documentation.