### PR TITLE
Fix for Spelling Mistake

### DIFF
--- a/website/docs/concepts/reading.mdx
+++ b/website/docs/concepts/reading.mdx
@@ -72,7 +72,7 @@ A typical [ConsumerWidget] would look like:
 #### Extending ConsumerStatefulWidget+ConsumerState instead of StatefulWidget+State
 
 Similar to [ConsumerWidget], [ConsumerStatefulWidget] and [ConsumerState] are the equivalent of a
-[StatefulWidget] with its [State], with the difference that the state as a "ref" object.
+[StatefulWidget] with its [State], with the difference that the state has a "ref" object.
 
 This time, the "ref" isn't passed as parameter of the build method, but is rather
 a property of the [ConsumerState] object:


### PR DESCRIPTION
Fixes a minor spelling mistake. Changes `as` to `has`.