### PR TITLE
🐛 Avoid dispose before emitting value for AutoDisposeProvider

### DIFF
--- a/packages/riverpod/lib/src/provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/provider/auto_dispose.dart
@@ -57,6 +57,15 @@ class AutoDisposeProviderElement<State>
 
   @override
   set state(State newState) => setState(newState);
+
+  @override
+  void dispose() {
+    if(state is Future) {
+      (state as Future).then((dynamic value) => super.dispose());
+    } else {
+      super.dispose();
+    }
+  }
 }
 
 /// {@macro riverpod.provider.family}

--- a/packages/riverpod/lib/src/provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/provider/auto_dispose.dart
@@ -60,8 +60,8 @@ class AutoDisposeProviderElement<State>
 
   @override
   void dispose() {
-    if(state is Future) {
-      (state as Future).then((dynamic value) => super.dispose());
+    if (state is Future) {
+      (state as Future).whenComplete(() => super.dispose());
     } else {
       super.dispose();
     }

--- a/packages/riverpod/test/providers/future_provider/auto_dispose_future_provider_test.dart
+++ b/packages/riverpod/test/providers/future_provider/auto_dispose_future_provider_test.dart
@@ -65,6 +65,16 @@ void main() {
     await expectLater(container.read(provider.future), completion(0));
   });
 
+  test('waiting until provider has been loaded', () async {
+    final provider = FutureProvider.autoDispose((ref) async {
+      await Future<void>.delayed(const Duration(seconds: 1));
+      return 0;
+    });
+    final container = createContainer();
+
+    await expectLater(container.read(provider.future), completion(0));
+  });
+
   test('can return an error synchronously, bypassing AsyncLoading', () async {
     final provider =
         FutureProvider.autoDispose((ref) => throw UnimplementedError());


### PR DESCRIPTION
closes #601

Ignoring the value from an autodisposable woudn't even solve the issue, in my opinion. When reading a provider the listener still waits for a response (e.g.`ref.read(autoDispFutureProvider.future)` which only can be interrupted from an exception, or will wait forever. So I suggest to just wait for the value, which I would expect to be returned.