### PR TITLE
Fix typo in Japanese docs

### DIFF
--- a/website/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ja/docusaurus-theme-classic/footer.json
@@ -24,7 +24,7 @@
     "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
   },
   "copyright": {
-    "message": "Copyright © 2021 Remi Rousselet. {br} Built with Docusaurus.",
+    "message": "Copyright © 2021 Remi Rousselet. <br /> Built with Docusaurus.",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
Hi, I found a simple typo in the Japanese documentation. 