### PR TITLE
[document] fix minor issues/typos

### DIFF
--- a/website/docs/concepts/provider_observer.mdx
+++ b/website/docs/concepts/provider_observer.mdx
@@ -12,7 +12,7 @@ To use it, extend the class ProviderObserver and override the method you like to
 
 [ProviderObserver] has three methods :
 
-- `didAddProvider` is called every time a provider was initialized, and the value exposed is value.
+- `didAddProvider` is called every time a provider was initialized, and the value exposed is `value`.
 - `didDisposeProvider` is called every time A provider was disposed
 - `didUpdateProvider` is called every time my providers when they emit a notification.
 

--- a/website/docs/cookbooks/testing_original_test_dart.dart
+++ b/website/docs/cookbooks/testing_original_test_dart.dart
@@ -45,7 +45,7 @@ void main() {
 
   test('the counter state is not shared between tests', () {
     // We use a different ProviderContainer to read our provider.
-    // This unsure that no state is reused between tests
+    // This ensure that no state is reused between tests
     final container = ProviderContainer();
     addTearDown(container.dispose);
     final listener = Listener();

--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -82,7 +82,7 @@ dependencies:
   riverpod: ^2.0.0-dev.0
 ```
 
-Then run `pub get`.
+Then run `dart pub get`.
 
 </TabItem>
 </Tabs>
@@ -134,7 +134,7 @@ This will print "Hello world" in the console.
 
 ## Going further: Installing code snippets
 
-If you are using `Flutter` and `Vscode` , consider using [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
+If you are using `Flutter` and `VS Code` , consider using [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
 
 If you are using `Flutter` and `Android Studio` or `IntelliJ`, consider using [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
 

--- a/website/docs/getting_started_hello_world_hooks.dart
+++ b/website/docs/getting_started_hello_world_hooks.dart
@@ -20,7 +20,7 @@ void main() {
   );
 }
 
-// Note: MyApp is a HookConsumerWidget, from flutter_hooks.
+// Note: MyApp is a HookConsumerWidget, from hooks_riverpod.
 class MyApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/website/docs/migration/0.13.0_to_0.14.0.mdx
+++ b/website/docs/migration/0.13.0_to_0.14.0.mdx
@@ -38,6 +38,8 @@ class MyStateNotifier extends StateNotifier<MyModel> {
 
 - to obtain the [StateNotifier], you should now read `myProvider.notifier` instead of just `myProvider`:
 
+  Before:
+
   ```dart
   Widget build(BuildContext context, ScopedReader watch) {
     MyStateNotifier notifier = watch(provider);
@@ -85,7 +87,7 @@ dart pub global activate riverpod_cli
 
 You should now be able to do:
 
-```dart
+```sh
 riverpod --help
 ```
 

--- a/website/docs/migration/0.14.0_to_1.0.0.mdx
+++ b/website/docs/migration/0.14.0_to_1.0.0.mdx
@@ -23,7 +23,7 @@ dart pub global activate riverpod_cli
 
 You should now be able to do:
 
-```dart
+```sh
 riverpod --help
 ```
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -77,7 +77,7 @@ dependencies:
   riverpod: ^1.0.0-dev.10
 ```
 
-Then run `pub get`.
+Then run `dart pub get`.
 
 </TabItem>
 </Tabs>
@@ -220,7 +220,7 @@ Cela va afficher "Hello world" dans la console.
 
 ## Aller plus loin: Installer des raccourcis de code
 
-Si vous utilisez `Flutter` et `Vscode` , considérez l'installation des [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
+Si vous utilisez `Flutter` et `VS Code` , considérez l'installation des [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
 
 Si vous utilisez `Flutter` et `Android Studio`/`IntelliJ`, considérez l'installation des [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -86,7 +86,7 @@ dart pub global activate riverpod_cli
 
 Vous devriez maintenant être en mesure de faire :
 
-```dart
+```sh
 riverpod --help
 ```
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
@@ -23,7 +23,7 @@ dart pub global activate riverpod_cli
 
 Vous devriez normalement ensuite pouvoir faire:
 
-```dart
+```sh
 riverpod --help
 ```
 

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -77,7 +77,7 @@ dependencies:
   riverpod: ^1.0.2
 ```
 
-Dopodichè esegui `pub get`.
+Dopodichè esegui `dart pub get`.
 
 </TabItem>
 </Tabs>
@@ -121,7 +121,7 @@ void main() {
   );
 }
 
-// Nota: MyApp è un HookConsumerWidget, da flutter_hooks
+// Nota: MyApp è un HookConsumerWidget, da hooks_riverpod
 class MyApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -215,7 +215,7 @@ Questo mostrerà "Hello world" nella console
 
 ## Andando oltre: Installare snippet
 
-Se stai utilizzando `Flutter` e `Vscode`, considera l'utilizzo di [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
+Se stai utilizzando `Flutter` e `VS Code`, considera l'utilizzo di [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
 
 Se stai utilizzando `Flutter` e `Android Studio` o `IntelliJ`, considera l'utilizzo di [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
 


### PR DESCRIPTION
This PR will fix minor issues/typos I've found in the En document during the translation.


1. To be more clear about `value` coming from a parameter name:

> the value exposed is value
> the value exposed is `value`


2. A typo:

> unsure
> ensure


3. Aligning with other parts of the before/after comparison, add:

> Before:


4. Seems the `pub get` command is [no longer available](https://github.com/Dart-Code/Dart-Code/issues/2944):

> `pub get`
> `dart pub get`


5. Aligning with the official abbreviation:

> `Vscode`
> `VS Code`


6. HookConsumerWidget comes from hooks_riverpod:

> flutter_hooks
> hooks_riverpod


7.

> dart
> sh

FYI: These are already fixed in the Ja docs.