### PR TITLE
Add Spanish docs translation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ["docusaurus-plugin-sass"],
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "fr", "ko", "ja"],
+    locales: ["en", "fr", "ko", "ja", "es"],
   },
   themeConfig: {
     googleAnalytics: {

--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -4,7 +4,7 @@
     "description": "The title of the 404 page"
   },
   "theme.NotFound.p1": {
-    "message": "No pudimos encontrar por lo que estabas buscando.",
+    "message": "No pudimos encontrar lo que estabas buscando.",
     "description": "The first paragraph of the 404 page"
   },
   "theme.NotFound.p2": {
@@ -227,7 +227,7 @@
     "description": "The homepage input placeholder"
   },
   "home.recompute_title": {
-    "message": "Recalcular el estado y reconstruir el interfaz solo cuando sea necesario."
+    "message": "Recalcular el estado y reconstruir el interfaz solo cuando sea necesario"
   },
   "home.recompute_body": {
     "message": "Ya no tenemos que ordenar y/o filtrar listas dentro del método {build} o tener que recurrir a un mecanismo de caché avanzado.{br}{br} Con {Provider} y {families}, puedes ordenar tus listas o hacer solicitudes HTTP solo cuando realmente lo necesites."
@@ -242,7 +242,7 @@
     "message": "Inspecciona tu estado en el devtool"
   },
   "home.devtool_body": {
-    "message": "Usando Riverpod, por defecto, tu estado es visible dentro del devtool de Flutter. Por si fuera poco, una herramienta integral de inspección de estados esta en camino."
+    "message": "Usando Riverpod, por defecto, tu estado es visible dentro del devtool de Flutter. Por si fuera poco, una herramienta integral de inspección de estados esta en desarrollo."
   },
   "home.create_provider": {
     "message": "Crea un Provider"

--- a/website/i18n/es/code.json
+++ b/website/i18n/es/code.json
@@ -1,0 +1,259 @@
+{
+  "theme.NotFound.title": {
+    "message": "Página No Encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "No pudimos encontrar por lo que estabas buscando.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Por favor comuníquese con el propietario del sitio que lo vinculó a la URL original e infórmele que su vínculo no funciona.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "De cerca",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Paginación de la lista de publicaciones del blog",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Nuevas entradas",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Entradas antiguas",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Un minuto de lectura|{readingTime} minutos de lectura",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Etiquetas: ",
+    "description": "The label alongside a tag list"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Leer más",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Paginación de publicaciones del blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Publicación más reciente",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Publicación más antigua",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navegación de publicaciones recientes del blog",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Un artículo|{count} artículos",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} etiquetadas con « {tagName} »",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver todas las etiquetas",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Etiquetas",
+    "description": "The title of the tag list page"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Desplegar el menú lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Desplegar el menú lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Paginación de documentos",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Siguiente",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Ocultar menú lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Ocultar menú lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta es la documentación para la próxima versión {versionLabel} de {siteTitle}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta es la documentación de {siteTitle} {versionLabel}, que ya no se mantiene activamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Haga clic aquí para obtener la documentación de la última versión [{versionLabel}]: {latestVersionLink}",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "Última versión",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar esta página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Enlace directo al título",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "Última fecha de actualización: {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "Última actualización por: {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última actualización el {atDate} por {byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Volver al menú principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Saltar al contenido principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "En esta página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "Un documento encontrado|{count} documentos encontrados",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Resultados de la búsqueda de « {query} »",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Buscar documentos.",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Escriba su búsqueda aquí",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Buscar",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Búsqueda por Algolia",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "Ningún resultado encontrado",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Cargando nuevos resultados...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Buscar",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "homepage.compile_safe_title": {
+    "message": "Compilación segura"
+  },
+  "homepage.compile_safe_body": {
+    "message": "No más {ProviderNotFound} u olvidarse de manejar los estados de carga. Usando Riverpod, si tu código compila, funciona. "
+  },
+  "homepage.unlimited_provider_title": {
+    "message": "Provider, sin sus limitaciones"
+  },
+  "homepage.unlimited_provider_body": {
+    "message": "Riverpod está inspirado en Provider pero resuelve algunos de sus problemas clave, como soportar múltiples providers del mismo tipo; esperar por providers asincrónicos; agregar providers desde cualquier lugar, ..."
+  },
+  "homepage.no_flutter_dependency_title": {
+    "message": "No depende de Flutter"
+  },
+  "homepage.no_flutter_dependency_body": {
+    "message": "Crea/comparte/prueba providers, sin depender de Flutter. Esto incluye poder escuchar providers sin un {BuildContext}."
+  },
+  "home.tagline": {
+    "message": "Un Framework Reactivo de Manejo de Estados e Inyección de Dependencias"
+  },
+  "home.get_started": {
+    "message": "Empezar"
+  },
+  "home.shared_state_title": {
+    "message": "Declara un estado compartido desde cualquier lugar"
+  },
+  "home.shared_state_body": {
+    "message": "Ya no es necesario saltar entre tu {main} y tus archivos de interfaz de usuario. Escribe el código de tu estado compartido donde pertenece, ya sea en un paquete separado o justo al lado del Widget que lo necesita, sin perder la capacidad de hacer pruebas.",
+    "description": "The homepage input placeholder"
+  },
+  "home.recompute_title": {
+    "message": "Recalcular el estado y reconstruir el interfaz solo cuando sea necesario."
+  },
+  "home.recompute_body": {
+    "message": "Ya no tenemos que ordenar y/o filtrar listas dentro del método {build} o tener que recurrir a un mecanismo de caché avanzado.{br}{br} Con {Provider} y {families}, puedes ordenar tus listas o hacer solicitudes HTTP solo cuando realmente lo necesites."
+  },
+  "home.safe_read_title": {
+    "message": "Lea los providers de forma segura"
+  },
+  "home.safe_read_body": {
+    "message": "Leer un provider nunca resultará en un mal estado. Si puedes escribir el código necesario para leer un provider, obtendrás un valor válido. {br}{br} Esto incluso se aplica a los valores obtenidos de forma asíncrona. A diferencia de Provider, Riverpod te permite manejar de forma limpia los casos de carga y error."
+  },
+  "home.devtool_title": {
+    "message": "Inspecciona tu estado en el devtool"
+  },
+  "home.devtool_body": {
+    "message": "Usando Riverpod, por defecto, tu estado es visible dentro del devtool de Flutter. Por si fuera poco, una herramienta integral de inspección de estados esta en camino."
+  },
+  "home.create_provider": {
+    "message": "Crea un Provider"
+  },
+  "home.consume_provider": {
+    "message": "Consume el Provider"
+  },
+  "declare_anywhere_img": {
+    "message": "img/intro/fr/declare_anywhere.png"
+  },
+  "home.async_img": {
+    "message": "img/intro/fr/async.png"
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -24,7 +24,7 @@
     "description": "The label for category Official examples in sidebar Sidebar"
   },
   "sidebar.Sidebar.category.Third party examples": {
-    "message": "Ejemplos de la comunidad",
+    "message": "Ejemplos de terceros",
     "description": "The label for category Third party examples in sidebar Sidebar"
   },
   "sidebar.Sidebar.category.Api references": {

--- a/website/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,110 @@
+{
+  "version.label": {
+    "message": "Siguiente",
+    "description": "The label for version current"
+  },
+  "sidebar.Sidebar.category.Guides": {
+    "message": "Guías",
+    "description": "The label for category Guides in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Concepts": {
+    "message": "Conceptos",
+    "description": "The label for category Concepts in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Modifiers": {
+    "message": "Modificadores",
+    "description": "The label for category Modifiers in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Migration": {
+    "message": "Migración",
+    "description": "The label for category Migration in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Official examples": {
+    "message": "Ejemplos oficiales",
+    "description": "The label for category Official examples in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Third party examples": {
+    "message": "Ejemplos de la comunidad",
+    "description": "The label for category Third party examples in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Api references": {
+    "message": "Referencias del Api",
+    "description": "The label for category Api references in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.link.Counter": {
+    "message": "Contador",
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+  },
+  "sidebar.Sidebar.link.Todo list": {
+    "message": "Lista de Tareas",
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+  },
+  "sidebar.Sidebar.link.Marvel API": {
+    "message": "API de Marvel",
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+  },
+  "sidebar.Sidebar.link.Android Launcher": {
+    "message": "Android Launcher",
+    "description": "The label for link Android Launcher in sidebar Sidebar, linking to https://github.com/lohanidamodar/fl_live_launcher"
+  },
+  "sidebar.Sidebar.link.Worldtime Clock": {
+    "message": "Reloj Mundial",
+    "description": "The label for link Worldtime Clock in sidebar Sidebar, linking to https://github.com/lohanidamodar/flutter_worldtime"
+  },
+  "sidebar.Sidebar.link.Dictionary App": {
+    "message": "App de Diccionario",
+    "description": "The label for link Dictionary App in sidebar Sidebar, linking to https://github.com/lohanidamodar/fl_dictio"
+  },
+  "sidebar.Sidebar.link.Firebase Starter": {
+    "message": "Proyecto de Inicio con Firebase",
+    "description": "The label for link Firebase Starter in sidebar Sidebar, linking to https://github.com/lohanidamodar/flutter_firebase_starter/tree/feature/riverpod"
+  },
+  "sidebar.Sidebar.link.Time Tracking App (with Firebase)": {
+    "message": "App de Gestión del Tiempo con Firebase",
+    "description": "The label for link Time Tracking App (with Firebase) in sidebar Sidebar, linking to https://github.com/bizz84/starter_architecture_flutter_firebase"
+  },
+  "sidebar.Sidebar.link.Firebase Phone Authentication with Riverpod": {
+    "message": "Autenticación por Teléfono con Firebase",
+    "description": "The label for link Firebase Phone Authentication with Riverpod in sidebar Sidebar, linking to https://github.com/julienlebren/flutter_firebase_phone_auth_riverpod"
+  },
+  "sidebar.Sidebar.link.ListView paging with search": {
+    "message": "ListView: Paginación con búsqueda",
+    "description": "The label for link ListView paging with search in sidebar Sidebar, linking to https://github.com/tbm98/flutter_loadmore_search"
+  },
+  "sidebar.Sidebar.link.Resocoder's Weather Bloc to Weather Riverpod": {
+    "message": "App de Clima: Migración de Bloc a Riverpod por Resocoder",
+    "description": "The label for link Resocoder's Weather Bloc to Weather Riverpod in sidebar Sidebar, linking to https://github.com/campanagerald/flutter-bloc-library-v1-tutorial"
+  },
+  "sidebar.Sidebar.link.Blood Pressure Tracker App": {
+    "message": "App de Presión Arterial",
+    "description": "The label for link Blood Pressure Tracker App in sidebar Sidebar, linking to https://github.com/UrosTodosijevic/blood_pressure_tracker"
+  },
+  "sidebar.Sidebar.link.Firebase Authentication with Riverpod Following Flutter DDD Architecture Pattern": {
+    "message": "Autenticación con Firebase y Riverpod usando el Patrón de Arquitectura DDD para Flutter",
+    "description": "The label for link Firebase Authentication with Riverpod Following Flutter DDD Architecture Pattern in sidebar Sidebar, linking to https://github.com/pythonhubpy/firebase_authentication_flutter_DDD"
+  },
+  "sidebar.Sidebar.link.Todo App with Backup and Restore feature": {
+    "message": "Lista de Tareas con Restauración de Copias de Seguridad",
+    "description": "The label for link Todo App with Backup and Restore feature in sidebar Sidebar, linking to https://github.com/TheAlphaApp/flutter_riverpod_todo_app"
+  },
+  "sidebar.Sidebar.link.Integrating Hive database with Riverpod (simple example)": {
+    "message": "Integración de Hive con Riverpod (ejemplo simple)",
+    "description": "The label for link Integrating Hive database with Riverpod (simple example) in sidebar Sidebar, linking to https://github.com/GitGud31/theme_riverpod_hive"
+  },
+  "sidebar.Sidebar.category.All Providers": {
+    "message": "Todos los Providers",
+    "description": "The label for category All Providers in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.link.riverpod": {
+    "message": "riverpod",
+    "description": "The label for link riverpod in sidebar Sidebar, linking to https://pub.dev/documentation/riverpod/latest/riverpod/riverpod-library.html"
+  },
+  "sidebar.Sidebar.link.flutter_riverpod": {
+    "message": "flutter_riverpod",
+    "description": "The label for link flutter_riverpod in sidebar Sidebar, linking to https://pub.dev/documentation//flutter_riverpod/latest/flutter_riverpod/flutter_riverpod-library.html"
+  },
+  "sidebar.Sidebar.link.hooks_riverpod": {
+    "message": "hooks_riverpod",
+    "description": "The label for link hooks_riverpod in sidebar Sidebar, linking to https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/hooks_riverpod-library.html"
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -1,0 +1,268 @@
+---
+title: Combinando providers
+---
+
+Asegúrese de [leer primero acerca de los providers](/docs/concepts/providers).
+En esta guía, veremos todo lo que hay que saber sobre la combinación de providers.
+
+### Combinando providers
+
+Anteriormente hemos visto cómo crear un provider simple. Pero la realidad es que, 
+en muchas situaciones, un provider querrá leer el estado de otro provider.
+
+Para hacer eso, podemos usar el objeto `ref` pasado al callback de nuestro 
+provider y usar su método `watch`.
+
+Como ejemplo, considere el siguiente provider:
+
+```dart
+final cityProvider = Provider((ref) => 'London');
+```
+
+Ahora podemos crear otro provider que consumirá nuestro `cityProvider`:
+
+```dart
+final weatherProvider = FutureProvider((ref) async {
+  // Usamos `ref.watch` para escuchar a otro provider, y le pasamos el provider 
+  // que queremos consumir. 
+  // Aquí: cityProvider
+  final city = ref.watch(cityProvider);
+
+  // Entonces podemos usar el resultado para hacer algo basado en el valor de `cityProvider`.
+  return fetchWeather(city: city);
+});
+```
+
+Eso es. Hemos creado un provider que depende de otro provider.
+
+## Preguntas frecuentes
+
+### ¿Qué pasa si el valor que escuchamos cambia con el tiempo?
+
+Dependiendo del provider que esté escuchando, el valor obtenido puede cambiar con el tiempo. 
+Por ejemplo, es posible que esté escuchando un [StateNotifierProvider] , o que el provider que 
+está escuchando se haya visto obligado a actualizar mediante el uso de [ProviderContainer.refresh]/[ref.refresh].
+
+Al usar [watch], Riverpod puede detectar que el valor que se escucha cambió y volverá a ejecutar 
+_automáticamente_ el provider cuando sea necesario.
+
+Esto puede ser útil para los estados calculados (computed states). Por ejemplo, considere un [StateNotifierProvider] 
+que expone una lista de tareas pendientes:
+
+```dart
+class TodoList extends StateNotifier<List<Todo>> {
+  TodoList(): super(const []);
+}
+
+final todoListProvider = StateNotifierProvider((ref) => TodoList());
+```
+Un caso de uso común sería hacer que la interfaz de usuario filtre la lista de todos para mostrar
+solo las tareas completados/incompletos.
+
+Una manera fácil de implementar tal escenario sería:
+
+- cree un [StateProvider], que expone el método de filtro seleccionado actualmente:
+
+ ```dart
+  enum Filter {
+    none,
+    completed,
+    uncompleted,
+  }
+
+  final filterProvider = StateProvider((ref) => Filter.none);
+  ```
+- cree un provider separado que combine el método de filtro 
+  y la lista de tareas para exponer la lista de tareas filtrada:
+
+  ```dart
+  final filteredTodoListProvider = Provider<List<Todo>>((ref) {
+    final filter = ref.watch(filterProvider);
+    final todos = ref.watch(todoListProvider);
+
+    switch (filter) {
+      case Filter.none:
+        return todos;
+      case Filter.completed:
+        return todos.where((todo) => todo.completed).toList();
+      case Filter.uncompleted:
+        return todos.where((todo) => !todo.completed).toList();
+    }
+  });
+  ```
+
+Luego, nuestra interfaz de usuario puede escuchar a `filteredTodoListProvider` para escuchar la lista de tareas filtrada.
+Con este enfoque, la interfaz de usuario se actualizará automáticamente cuando cambie el filtro o la lista de tareas pendientes.
+
+Para ver este enfoque en acción, puede consultar el código fuente del ejemplo de [Lista de Tareas](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
+
+:::info
+Este comportamiento no es específico de [Provider] y funciona con todos los providers.
+
+Por ejemplo, podría combinar [watch] con [FutureProvider] para implementar una función de búsqueda 
+que admita cambios de configuración en vivo:
+
+```dart
+// El filtro de búsqueda actual
+final searchProvider = StateProvider((ref) => '');
+
+/// Configuraciones que pueden cambiar con el tiempo
+final configsProvider = StreamProvider<Configuration>(...);
+
+final charactersProvider = FutureProvider<List<Character>>((ref) async {
+  final search = ref.watch(searchProvider);
+  final configs = await ref.watch(configsProvider.last);
+  final response = await dio.get('${configs.host}/characters?search=$search');
+
+  return response.data.map((json) => Character.fromJson(json)).toList();
+});
+```
+
+Este código obtendrá una lista de personajes del servicio y volverá a obtener 
+automáticamente la lista cada vez que cambien las configuraciones o cuando cambie la consulta de búsqueda.
+:::
+
+### ¿Puedo leer un provider sin escucharlo?
+
+A veces, queremos leer el contenido de un provider, pero sin recrear el valor expuesto cuando cambia el valor obtenido.
+
+Un ejemplo sería un `Repository`, que lee de otro provider el token de usuario para la autenticación.
+Podríamos usar [watch] y crear uno nuevo `Repository` cada vez que cambie el token de usuario, pero no sirve de nada hacerlo.
+ 
+En esta situación, podemos usar [read], que es similar a [watch], pero no hará que el provider vuelva a crear el valor que expone cuando cambia el valor obtenido.
+
+En ese caso, una práctica común es pasar `ref.read` al objeto creado. El objeto creado podrá leer providers cuando quiera.
+
+
+```dart
+final userTokenProvider = StateProvider<String>((ref) => null);
+
+final repositoryProvider = Provider((ref) => Repository(ref.read));
+
+class Repository {
+  Repository(this.read);
+
+  /// La fonction `ref.read` 
+  final Reader read;
+
+  Future<Catalog> fetchCatalog() async {
+    String token = read(userTokenProvider);
+
+    final response = await dio.get('/path', queryParameters: {
+      'token': token,
+    });
+
+    return Catalog.fromJson(response.data);
+  }
+}
+```
+
+:::note NOTA
+También podría pasar el `ref` en lugar de `ref.read` a su objeto:
+
+```dart
+final repositoryProvider = Provider((ref) => Repository(ref));
+
+class Repository {
+  Repository(this.ref);
+
+  final Ref ref;
+}
+```
+Sin embargo, pasar `ref.read` da como resultado un código un poco menos verboso 
+y asegura que nuestro objeto nunca usará `ref.watch`.
+:::
+
+:::danger **NO** uses [read] dentro del cuerpo de un provider
+
+```dart
+final myProvider = Provider((ref) {
+  // Mala práctica para llamar `read` aquí.
+  final value = ref.read(anotherProvider);
+});
+```
+Si utilizó la [read] como un intento de evitar reconstrucciones no deseadas de su objeto, 
+consulte [Mi provider se actualiza con demasiada frecuencia, ¿qué puedo hacer?](#mi-provider-se-actualiza-con-demasiada-frecuencia-qué-puedo-hacer)
+:::
+
+### ¿Cómo testear un objeto que recibe [read] como parámetro de su constructor?
+
+Si está utilizando el patrón descrito en [¿Puedo leer un provider sin escucharlo?](#puedo-leer-un-provider-sin-escucharlo), 
+es posible que se pregunte cómo escribir pruebas para su objeto.
+
+En este escenario, considere testear el provider directamente en lugar del objeto sin procesar (raw). 
+Puede hacerlo utilizando la clase [ProviderContainer]:
+
+```dart
+final repositoryProvider = Provider((ref) => Repository(ref.read));
+
+test('fetches catalog', () async {
+  final container = ProviderContainer();
+  addTearOff(container.dispose);
+
+  Repository repository = container.read(repositoryProvider);
+
+  await expectLater(
+    repository.fetchCatalog(),
+    completion(Catalog()),
+  );
+});
+```
+
+### Mi provider se actualiza con demasiada frecuencia, ¿qué puedo hacer?
+
+Si su objeto se vuelve a crear con demasiada frecuencia, es probable que su provider esté 
+escuchando objetos que no le interesan.
+
+Por ejemplo, puede estar escuchando un objeto `Configuration`, pero solo usa la propiedad `host`. 
+Al escuchar todo el objeto `Configuration`, si `host` cambia una propiedad que no sea la misma, 
+esto provocaría que su provider sea reevaluado, lo que puede no ser deseado.
+
+La solución a este problema es crear un provider separado que exponga _solo_ lo que necesita 
+en `Configuration`(entonces `host`):
+
+**EVITE** escuchar todo el objeto:
+
+```dart
+final configsProvider = StreamProvider<Configuration>(...);
+
+final productsProvider = FutureProvider<List<Product>>((ref) async {
+  // Hará que productsProvider vuelva a obtener los productos si algo
+  // cambio en la configuración
+  final configs = await ref.watch(configsProvider.last);
+
+  return dio.get('${configs.host}/products');
+});
+```
+
+**PREFIERA** escuchar solo lo que usas:
+
+
+```dart
+final configsProvider = StreamProvider<Configuration>(...);
+
+/// Un provider que expone solo el host actual
+final _hostProvider = FutureProvider<String>((ref) async {
+  final config = await ref.watch(configsProvider.last);
+  return config.host;
+});
+
+final productsProvider = FutureProvider<List<Product>>((ref) async {
+  // Escucha solo al host. Si algo más en los cambios de las configuraciones 
+  // esto no volverá a evaluar inútilmente a nuestro provider.
+  final host = await ref.watch(_hostProvider.future);
+
+  return dio.get('$host/products');
+});
+```
+
+[provider]: https://pub.dev/documentation/riverpod/latest/riverpod/Provider-class.html
+[stateprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateProvider-class.html
+[futureprovider]: ../providers/future_provider
+[statenotifierprovider]: ../providers/state_notifier_provider
+[ref]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref-class.html
+[watch]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/watch.html
+[read]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/read.html
+[providercontainer.refresh]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer/refresh.html
+[ref.refresh]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/WidgetRef/refresh.html
+[providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/modifiers/auto_dispose.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/modifiers/auto_dispose.mdx
@@ -1,0 +1,129 @@
+---
+title: .autoDispose
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Un caso de uso común cuando se usan providers es querer destruir 
+el estado de un provider cuando ya no se usa.
+
+Hay múltiples razones para hacerlo, tales como:
+
+- Al usar Firebase, para cerrar la conexión y evitar costos innecesarios.
+- Para restablecer el estado cuando el usuario sale de una pantalla y vuelve a entrar.
+
+Los providers vienen con soporte incorporado para tales casos de uso, 
+a través del modificador `.autoDispose`.
+
+## Uso
+
+Para decirle a Riverpod que destruya el estado de un provider cuando ya no se use, 
+simplemente agregue `.autoDispose` a su provider:
+
+```dart
+final userProvider = StreamProvider.autoDispose<User>((ref) {
+
+});
+```
+
+Eso es. Ahora, el estado de `userProvider` se destruirá automáticamente cuando ya no se use.
+
+Tenga en cuenta cómo los parámetros genéricos se pasan después de `autoDispose` y no antes - 
+`autoDispose` no es un constructor con nombre (named constructor).
+
+:::note NOTA
+Puede combinar `.autoDispose` con otros modificadores si lo necesitas:
+
+```dart
+final userProvider = StreamProvider.autoDispose.family<User, String>((ref, id) {
+
+});
+```
+
+:::
+
+### ref.maintainState
+
+Marcar un provider con `autoDispose` también agrega una propiedad adicional en `ref`:`maintainState`.
+
+La propiedad `maintainState` es un valor booleano (por defecto `false`) que permite al provider 
+decirle a Riverpod si el estado del provider debe conservarse incluso si ya no se escucha.
+
+Un caso de uso sería establecer este indicador `true` después de que se haya completado una solicitud HTTP:
+
+```dart
+final myProvider = FutureProvider.autoDispose((ref) async {
+  final response = await dio.get(...);
+  ref.maintainState = true;
+  return response;
+});
+```
+
+De esta manera, si la solicitud falla y el usuario sale de la pantalla y luego vuelve a ingresar, 
+entonces la solicitud se realizará nuevamente. Pero si la solicitud se completó con éxito, 
+el estado se conservará y volver a ingresar a la pantalla no activará una nueva solicitud.
+
+## Ejemplo: cancelar solicitudes HTTP cuando ya no se usan
+
+El modificador `autoDispose` podría combinarse con [FutureProvider] y `ref.onDispose` para cancelar 
+fácilmente las solicitudes HTTP cuando ya no sean necesarias.
+
+El objetivo es:
+
+- Iniciar una solicitud HTTP cuando el usuario ingresa a una pantalla
+- si el usuario abandona la pantalla antes de que se complete la solicitud, cancele la solicitud HTTP
+- si la solicitud tuvo éxito, salir y volver a ingresar a la pantalla no inicia una nueva solicitud
+
+En código, esto sería:
+
+```dart
+final myProvider = FutureProvider.autoDispose((ref) async {
+  // Un objeto de package:dio que permite cancelar solicitudes http
+  final cancelToken = CancelToken();
+  // Cuando se destruye el provider, cancelar la solicitud http
+  ref.onDispose(() => cancelToken.cancel());
+
+  // Obtener nuestros datos y pasar nuestro `cancelToken` para que la cancelación funcione
+  final response = await dio.get('path', cancelToken: cancelToken);
+  // Si la solicitud se completó con éxito, mantenga el estado
+  ref.maintainState = true;
+  return response;
+});
+```
+
+## El tipo de argumento 'AutoDisposeProvider' no se puede asignar al tipo de parámetro 'AlwaysAliveProviderBase'
+
+Al usar `.autoDispose`, puede encontrarse en una situación en la que su 
+aplicación no compila con un error similar a:
+
+> The argument type 'AutoDisposeProvider' can't be assigned to the parameter
+> type 'AlwaysAliveProviderBase'
+
+¡No te preocupes! Este error es voluntario. Sucede porque lo más probable es que tengas un error (bug):
+
+Intentó escuchar un provider marcado con `.autoDispose` en un provider que **no** está marcado 
+con `.autoDispose`, como:
+
+```dart
+final firstProvider = Provider.autoDispose((ref) => 0);
+
+final secondProvider = Provider((ref) {
+  // The argument type 'AutoDisposeProvider<int>' can't be assigned to the
+  // parameter type 'AlwaysAliveProviderBase<Object, Null>'
+  ref.watch(firstProvider);
+});
+```
+
+Esto no es deseable, ya que haría que `firstProvider` nunca se desechara.
+
+Para arreglar esto, considere también marcar `secondProvider` con `.autoDispose`:
+
+```dart
+final firstProvider = Provider.autoDispose((ref) => 0);
+
+final secondProvider = Provider.autoDispose((ref) {
+  ref.watch(firstProvider);
+});
+```
+[futureprovider]: ../../providers/future_provider

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/modifiers/family.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/modifiers/family.mdx
@@ -180,4 +180,4 @@ Widget build(BuildContext context, WidgetRef ref) {
 [freezed]: https://pub.dev/packages/freezed
 [provider]: https://pub.dev/documentation/riverpod/latest/riverpod/Provider-class.html
 [equatable]: https://pub.dev/packages/equatable
-[futureprovider]: ../providers/future_provider
+[futureprovider]: ../../providers/future_provider

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/modifiers/family.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/modifiers/family.mdx
@@ -1,0 +1,183 @@
+---
+title: .family
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Antes de leer esto, considere leer acerca de los [providers](/docs/concepts/providers) y [cómo leerlos](/docs/concepts/reading). 
+En esta parte, hablaremos en detalle sobre el modificador de providers `.family` .
+
+El modificador `.family` tiene un propósito: crear un provider a partir de valores externos.
+
+Algunos casos de uso comunes para `family` serían:
+
+- Combinando [FutureProvider] con `.family` para obtener (fetch) un `Message` de su ID.
+- Pasar el `Locale` actual a un provider, para que podamos manejar las traducciones.
+
+## Uso
+
+La forma en que funcionan las familias es agregando un parámetro adicional al provider.
+Este parámetro se puede usar libremente en nuestro provider para crear algún estado.
+
+Por ejemplo, podríamos combinar `family` con [FutureProvider] para obtener un `Message` a partir de su ID:
+
+```dart
+final messagesFamily = FutureProvider.family<Message, String>((ref, id) async {
+  return dio.get('http://my_api.dev/messages/$id');
+});
+```
+
+Luego, al usar nuestro provider `messagesFamily`, la sintaxis se modifica ligeramente.
+La sintaxis habitual ya no funcionará:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  // Error – messagesFamily no es un provider
+  final response = ref.watch(messagesFamily);
+}
+```
+
+En su lugar, necesitamos pasar un parámetro a `messagesFamily`:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  final response = ref.watch(messagesFamily('id'));
+}
+```
+
+:::info
+Es posible utilizar una familia con diferentes parámetros simultáneamente.
+Por ejemplo, podríamos usar a `titleFamily` para leer las traducciones al francés y al inglés al mismo tiempo:
+
+```dart
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  final frenchTitle = ref.watch(titleFamily(const Locale('fr')));
+  final englishTitle = ref.watch(titleFamily(const Locale('en')));
+
+  return Text('fr: $frenchTitle en: $englishTitle');
+}
+```
+
+:::
+
+## Restricciones de Parámetros
+
+
+Para que las familias funcionen correctamente, es fundamental que el parámetro que se 
+pasa a un provider tenga un valor consistente de `hashCode` y `==`.
+
+Idealmente, el parámetro debería ser un primitivo (bool/int/double/String), una constante (providers) 
+o un objeto inmutable que sobrescriba `==` y `hashCode`.
+
+### _PREFIERA_ usar `autoDispose` cuando el parámetro no es constante:
+
+Es posible que desee utilizar familias para pasar la entrada de un campo de búsqueda a su provider. 
+Pero ese valor puede cambiar a menudo y nunca volver a utilizarse.
+Esto podría causar el uso de memoria en vano ya que, de manera predeterminada, un provider nunca se destruye, incluso si ya no se usa.
+
+Usando ambos `.family` y `.autoDispose` corrige esa pérdida de memoria:
+
+```dart
+final characters = FutureProvider.autoDispose.family<List<Character>, String>((ref, filter) async {
+  return fetchCharacters(filter: filter);
+});
+```
+
+## Pasar múltiples parámetros a una familia
+
+Las familias no tienen soporte integrado para pasar múltiples valores a un provider.
+
+Por otro lado, ese valor podría ser _cualquier_ cosa (siempre que coincida con las restricciones mencionadas anteriormente).
+
+Esto incluye:
+
+- Una tupla de [tupla](http://pub.dev/packages/tuple).
+- Objetos generados con [Freezed] o [built_value](https://pub.dev/packages/built_value).
+- Objetos usando [equatable](https://pub.dev/packages/equatable).
+
+Aquí hay un ejemplo usando [Freezed] y [equatable]:
+
+<Tabs
+  groupId="family"
+  defaultValue="freezed"
+  values={[
+    { label: 'Freezed', value: 'freezed', },
+    { label: 'Equatable', value: 'equatable', },
+  ]}
+>
+
+<TabItem value="freezed">
+
+```dart
+@freezed
+abstract class MyParameter with _$MyParameter {
+  factory MyParameter({
+    required int userId,
+    required Locale locale,
+  }) = _MyParameter;
+}
+
+final exampleProvider = Provider.autoDispose.family<Something, MyParameter>((ref, myParameter) {
+  print(myParameter.userId);
+  print(myParameter.locale);
+  // Hacer algo con userId/locale
+});
+
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  int userId; // Leer el ID de usuario desde cualquier lugar
+  final locale = Localizations.localeOf(context);
+
+  final something = ref.watch(
+    exampleProvider(MyParameter(userId: userId, locale: locale)),
+  );
+
+  ...
+}
+```
+
+</TabItem>
+<TabItem value="equatable">
+
+```dart
+class MyParameter extends Equatable  {
+  MyParameter({
+    required this.userId,
+    required this.locale,
+  });
+
+  final int userId;
+  final Locale locale;
+
+  @override
+  List<Object> get props => [userId, locale];
+}
+
+final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  print(myParameter.userId);
+  print(myParameter.locale);
+  // Hacer algo con userId/locale
+});
+
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  int userId; // Leer el ID de usuario desde cualquier lugar
+  final locale = Localizations.localeOf(context);
+
+  final something = ref.watch(
+    exampleProvider(MyParameter(userId: userId, locale: locale)),
+  );
+
+  ...
+}
+```
+
+</TabItem>
+</Tabs>
+
+[freezed]: https://pub.dev/packages/freezed
+[provider]: https://pub.dev/documentation/riverpod/latest/riverpod/Provider-class.html
+[equatable]: https://pub.dev/packages/equatable
+[futureprovider]: ../providers/future_provider

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/provider_observer.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/provider_observer.mdx
@@ -1,0 +1,87 @@
+---
+title: ProviderObserver
+---
+
+[ProviderObserver] escucha los cambios de un ProviderContainer.
+
+Para usarlo, extienda la clase [ProviderObserver] y sobrescriba (override) el método que desea usar.
+
+ProviderObserver tiene tres métodos:
+
+- `didAddProviderse` llama cada vez que se inicializa un provider y el valor expuesto es `value`.
+- `didDisposeProvider` se llama cada vez que se destruyó (dispose) un provider.
+- `didUpdateProvider` es llamado cada vez por los providers cuando emiten una notificación.
+
+### Uso: 
+
+Un caso de uso simple para [ProviderObserver] es registrar los cambios en los providers 
+sobrescribiendo el método `didUpdateProvider`.
+
+```dart
+// Un ejemplo de Logger de Counter implementado con Riverpod 
+
+class Logger extends ProviderObserver {
+  @override
+  void didUpdateProvider(
+    ProviderBase provider,
+    Object? previousValue,
+    Object? newValue,
+    ProviderContainer container,
+  ) {
+    print('''
+{
+  "provider": "${provider.name ?? provider.runtimeType}",
+  "newValue": "$newValue"
+}''');
+  }
+}
+
+void main() {
+  runApp(
+    // Agregando ProviderScope habilita Riverpod para todo el proyecto 
+    // Agregamos nuestro Logger a la lista de observers (observadores)
+    ProviderScope(observers: [Logger()], child: MyApp()),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home: Home());
+  }
+}
+
+final counterProvider = StateProvider((ref) => 0);
+
+class Home extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Counter example')),
+      body: Center(
+        child: Consumer(builder: (context, ref, _) {
+          final count = ref.watch(counterProvider).state;
+          return Text('$count');
+        }),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read(counterProvider).state++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+```
+
+Ahora, cada vez que se actualice el valor de nuestro provider, el logger lo registrará:
+
+```
+I/flutter (16783): {
+I/flutter (16783):   "provider": "counter",
+I/flutter (16783):   "newValue": "Instance of 'StateController<int>'"
+I/flutter (16783): }
+```
+
+[providerobserver]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderObserver-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -1,0 +1,173 @@
+---
+title: Providers
+---
+
+Ahora que hemos instalado [Riverpod], hablemos de los "providers".
+
+Los providers son la parte más importante de una aplicación de [Riverpod]. 
+Un provider es un objeto que encapsula un estado y permite escuchar ese estado.
+
+
+## ¿Por qué usar providers?
+
+Al envolver una parte del estado en un provider, esto:
+
+- Permite acceder fácilmente a ese estado en múltiples ubicaciones. 
+  Los providers son un reemplazo completo para patrones como Singletons, 
+  Service Locators, Dependency Injection o InheritedWidgets.
+
+- Simplifica combinar este estado con otros. ¿Alguna vez te costó fusionar varios objetos en uno solo? 
+  Este escenario se construye directamente dentro de los providers, con una sintaxis simple.
+
+- Permite optimizaciones de rendimiento. 
+  Ya sea para filtrar reconstrucciones de widgets o para almacenar en caché 
+  demandantes cálculos de estado; los providers se aseguran de que solo se vuelva a 
+  calcular lo que se ve afectado por un cambio de estado.
+
+- Aumenta la capacidad de prueba de su aplicación. 
+  Con los providers, no necesita pasos complejos de `setUp`/`tearDown`. 
+  Además, se puede anular cualquier provider para que se comporte de manera diferente 
+  durante los test, lo que permite testear fácilmente un comportamiento muy específico.
+
+- Integre fácilmente con funciones avanzadas, como logging o pull-to-refresh.
+
+## Creando un provider
+
+Los providers vienen en muchas variantes, pero todos funcionan de la misma manera.
+
+El uso más común es declararlos como constantes globales así:
+
+```dart
+final myProvider = Provider((ref) {
+  return MyValue();
+});
+```
+
+:::note NOTA
+No tengas miedo por el aspecto global de los providers. 
+Los providers son totalmente inmutables. Declarar un provider no es 
+diferente de declarar una función, y es comprobable y mantenible.
+:::
+
+Este fragmento de código consta de tres componentes:
+
+- `final myProvider`, la declaración de una variable. 
+  Esta variable es la que usaremos en el futuro para leer el estado de nuestro provider. 
+  Siempre debe ser inmutable.
+
+- `Provider`, el provider que decidimos utilizar. 
+  [Provider] es el más básico de todos los providers. Expone un objeto que nunca cambia. 
+  Podríamos reemplazar [Provider] con otros providers como [StreamProvider] o 
+  [StateNotifierProvider], para cambiar la forma en que se interactúa con el valor.
+
+- Una función que crea el estado compartido. Esa función siempre recibirá un objeto 
+  llamado `ref` como parámetro. Este objeto nos permite leer otros providers o realizar 
+  algunas operaciones cuando el estado de nuestro provider será destruido.
+
+El tipo de objeto creado por la función pasada a un provider depende del provider utilizado. 
+Por ejemplo, la función de un [Provider] puede crear cualquier objeto. 
+Por otro lado, se espera que el callback de [StreamProvider] devuelva un [Stream].
+
+:::info
+Puedes declarar tantos providers como quieras sin limitaciones. 
+A diferencia de cuando usamos el `package:provider`, 
+en [Riverpod] podemos hacer que dos providers expongan un estado del mismo "tipo":
+
+```dart
+final cityProvider = Provider((ref) => 'London');
+final countryProvider = Provider((ref) => 'England');
+```
+
+El hecho de que ambos providers creen un `String` no supone ningún problema.
+
+:::
+
+:::caution PRECAUCIÓN
+Para que los providers funcionen, debe agregar [ProviderScope] en la raíz de sus aplicaciones de Flutter:
+
+```dart
+void main() {
+  runApp(ProviderScope(child: MyApp()));
+}
+```
+
+:::
+
+## Realizando acciones antes de la destrucción del estado
+
+En algunos casos, el estado de un provider puede destruirse o recrearse. 
+Un caso de uso común en esas situaciones es realizar una limpieza antes de que se 
+destruya el estado de un provider, como cerrar un `StreamController`.
+
+Esto se hace usando el objeto `ref`, que se pasa al `callback` de 
+todos los providers, usando su método [onDispose].
+
+El siguiente ejemplo usa [onDispose] para cerrar un `StreamController`:
+
+```dart
+final example = StreamProvider.autoDispose((ref) {
+  final streamController = StreamController<int>();
+
+  ref.onDispose(() {
+    // Cierra el StreamController cuando se destruye el estado de este provider.
+    streamController.close();
+  });
+
+  return streamController.stream;
+});
+```
+
+:::note NOTA
+Dependiendo del provider utilizado, es posible que ya se encargue del proceso de limpieza. 
+Por ejemplo, [StateNotifierProvider] llamará al método `dispose` de un `StateNotifier`.
+:::
+
+## Modificadores de Providers
+
+Todos los providers tienen una forma integrada de agregar funcionalidades adicionales a sus diferentes providers.
+
+
+Pueden agregar nuevas funciones al objeto `ref` o cambiar ligeramente la forma en que se consume el provider. 
+Los modificadores se pueden usar en todos los providers, con una sintaxis similar a los constructores nombrados:
+
+
+```dart
+final myAutoDisposeProvider = StateProvider.autoDispose<String>((ref) => 0);
+final myFamilyProvider = Provider.family<String, int>((ref, id) => '$id');
+```
+
+Por el momento, hay dos modificadores disponibles:
+
+- [`.autoDispose`](/docs/concepts/modifiers/auto_dispose), lo que hará que el provider destruya 
+  automáticamente su estado cuando ya no se escuche.
+- [`.family`](/docs/concepts/modifiers/family), lo que permite crear un provider a partir de 
+  parámetros externos.
+
+:::note NOTA
+Un provider puede usar múltiples modificadores a la misma vez:
+
+```dart
+final userProvider = FutureProvider.autoDispose.family<User, int>((ref, userId) async {
+  return fetchUser(userId);
+});
+```
+
+:::
+
+¡Eso es todo por esta guía!
+
+Puede continuar con [Cómo leer un provider](/docs/concepts/reading). 
+Alternativamente, puede ver [Cómo combinar providers](/docs/concepts/combining_providers).
+
+[get_it]: http://pub.dev/packages/get_it
+[inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
+[stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
+[ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
+[riverpod]: https://github.com/rrousselgit/river_pod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[provider]: ../providers/provider
+[streamprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StreamProvider-class.html
+[statenotifierprovider]: ../providers/state_notifier_provider
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -1,0 +1,566 @@
+---
+title: Leyendo un Provider
+--- 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Antes de leer esta guía, asegúrese de [leer primero acerca de los providers](/docs/concepts/providers).
+
+En esta guía, veremos cómo consumir un provider.
+
+## Obtener un objeto "ref"
+
+En primer lugar, antes de leer un provider, necesitamos obtener un objeto "ref".
+
+Este objeto es el que nos permite interactuar con los providers, ya sea desde un 
+widget o desde otro provider.
+
+### Obtener un "ref" de un provider
+
+Todos los providers reciben un "ref" como parámetro:
+
+```dart
+final provider = Provider((ref) {
+  // use ref para obtener otros providers
+  final repository = ref.watch(repositoryProvider);
+
+  return SomeValue(repository);
+})
+```
+Es seguro pasar este parámetro al valor expuesto por el provider.
+
+Por ejemplo, un caso de uso común es pasar la "ref" del provider a un [StateNotifier]:
+
+```dart
+final counter = StateNotifierProvider<Counter, int>((ref) {
+  return Counter(ref);
+});
+
+class Counter extends StateNotifier<int> {
+  Counter(this.ref): super(0);
+
+  final Ref ref;
+
+  void increment() {
+    // `Counter` puede usar la "ref" para leer otros providers
+    final repository = ref.read(repositoryProvider);
+    repository.post('...');
+  }
+}
+```
+
+Hacerlo permitiría que nuestra clase `Counter` lea providers.
+
+### Obtener un objeto "ref" de un widget
+
+Los widgets, naturalmente, no tienen un parámetro `ref`. 
+Pero [Riverpod] ofrece múltiples soluciones para obtener uno de los widgets.
+
+#### Exteniendo de ConsumerWidget en lugar de StatelessWidget
+
+La solución más común será reemplazar [StatelessWidget] por [ConsumerWidget] al crear un widget.
+
+[ConsumerWidget] es básicamente idéntico a [StatelessWidget], con la única diferencia 
+de que tiene un parámetro adicional en su método build: el objeto "ref".
+
+Un [ConsumerWidget] típico se vería así:
+
+```dart
+class HomeView extends ConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // use ref para escuchar un provider
+    final counter = ref.watch(counterProvider);
+    return Text('$counter');
+  }
+}
+```
+
+#### Exteniendo de ConsumerStatefulWidget+ConsumerState en lugar de StatefulWidget+State
+
+Al igual que [ConsumerWidget], [ConsumerStatefulWidget] y [ConsumerState] son el equivalente 
+de un [StatefulWidget] con su [State] (estado), con la diferencia de que el estado tiene un objeto "ref".
+
+Esta vez, la "ref" no se pasa como un parámetro del método de `build`, sino que es una 
+propiedad del objeto [ConsumerState]:
+
+```dart
+class HomeView extends ConsumerStatefulWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  HomeViewState createState() => HomeViewState();
+}
+
+class HomeViewState extends ConsumerState<HomeView> {
+  @override
+  void initState() {
+    super.initState();
+    // "ref" se puede utilizar en todos lo ciclos de vida de un StatefulWidget.
+    ref.read(counterProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // También podemos usar "ref" para escuchar a un provider dentro del método build
+    final counter = ref.watch(counterProvider);
+    return Text('$counter');
+  }
+}
+```
+
+#### Exteniendo un HookConsumerWidget en lugar de HookWidget
+
+Esta solución es específica para los usuarios de [flutter_hooks]. Dado que [flutter_hooks] 
+requiere extender [HookWidget] para funcionar, los widgets que usan hooks no pueden 
+extender [ConsumerWidget].
+
+Una solución, que es posible gracias al paquete [hooks_riverpod], es reemplazar [HookWidget] 
+con [HookConsumerWidget]. [HookConsumerWidget] actúa como [ConsumerWidget] y [HookWidget]. 
+Esto permite que un widget escuche a los providers y use hooks.
+
+Un ejemplo sería:
+
+```dart
+class HomeView extends HookConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // HookConsumerWidget permite usar hooks dentro del método build
+    final state = useState(0);
+
+    // También podemos usar el parámetro ref para escuchar a los providers.
+    final counter = ref.watch(counterProvider);
+    return Text('$counter');
+  }
+}
+```
+#### Widgets: Consumer y HookConsumer
+
+Una solución final para obtener una "ref" dentro de los widgets es usar 
+[Consumer]/[HookConsumer].
+
+Estas clases son widgets que se pueden usar para obtener un "ref", con las mismas 
+propiedades que [ConsumerWidget]/[HookConsumerWidget].
+
+Estos widgets pueden ser una forma de obtener una "ref" sin tener que definir una clase. 
+
+
+Un ejemplo sería:
+
+```dart
+Scaffold(
+  body: HookConsumer(
+    builder: (context, ref, child) {
+      // Al igual que HookConsumerWidget, podemos usar hooks dentro del builder.
+      final state = useState(0);
+
+      // También podemos usar el parámetro ref para escuchar a los providers.
+      final counter = ref.watch(counterProvider);
+      return Text('$counter');
+    },
+  ),
+)
+```
+
+## Uso de ref para interactuar con los providers
+
+Ahora que tenemos una "ref", podemos comenzar a usarla.
+
+Hay tres usos principales para "ref":
+
+- Obteniendo el valor de un provider y escuchando los cambios, de manera que cuando este valor cambie, 
+  este reconstruirá el widget o provider que se suscribió al valor. Eso se puede hacer usando `ref.watch`.
+- Agregando un listener a un provider, para ejecutar una acción cada vez que cambie ese provider.
+  Eso se puede hacer usando `ref.listen`.
+- Obteniendo el valor de un provider ignorando los cambios. Esto es útil cuando necesitamos el valor de un 
+  provider en una función callback de un evento, como en un `onPressed` callback. 
+  Eso se puede hacer usando `ref.read`.
+
+:::note NOTA
+Siempre que sea posible, prefiera usar `ref.watch` sobre `ref.read` o `ref.listen` para implementar una característica.
+Al cambiar su implementación para que dependa de `ref.watch`, se vuelve tanto reactivo como declarativo, 
+lo que hace que su aplicación sea más fácil de mantener.
+:::
+
+### Uso de ref.watch para observar a un provider
+
+Es posible usar `ref.watch` dentro del método build de un widget o dentro del cuerpo de un provider para que ese 
+widget/provider escuche al provider especificado por la llamada `ref.watch`:
+
+Por ejemplo, un provider podría usar `ref.watch` para combinar múltiples providers en un nuevo valor.
+
+Un ejemplo sería filtrar una lista de tareas pendientes. Podríamos tener dos providers:
+
+- `filterTypeProvider`, un provider que expone el tipo de filtro actual 
+  (ninguno, mostrar solo tareas completadas, ...)
+- `todosProvider`, un provider que expone la lista completa de tareas
+
+Y al usar `ref.watch`, podríamos crear un tercer provider que combine ambos providers 
+para crear una lista filtrada de tareas:
+
+```dart
+final filterTypeProvider = StateProvider<FilterType>((ref) => FilterType.none);
+final todosProvider = StateNotifierProvider<TodoList, List<Todo>>((ref) => TodoList());
+
+final filteredTodoListProvider = Provider((ref) {
+  // obtiene tanto el filtro como la lista de tareas
+  final FilterType filter = ref.watch(filterTypeProvider).state;
+  final List<Todo> todos = ref.watch(todosProvider);
+
+  switch (filter) {
+    case FilterType.completed:
+      // retorna la lista completa de tareas
+      return todos.where((todo) => todo.isCompleted).toList();
+    case FilterType.none:
+      // retorna la lista sin filtrar de tareas
+      return todos;
+  }
+});
+```
+
+Con este código, `filteredTodoListProvider` ahora expone la lista filtrada de tareas.
+
+La lista filtrada también se actualizará automáticamente si el filtro o la lista de tareas cambió. 
+Sin embargo, al mismo tiempo, la lista filtrada no se volverá a calcular si ni el filtro ni la lista 
+de tareas cambiaron.
+
+De manera similar, un widget podría usar `ref.watch` para mostrar una interfaz 
+de usuario que depende de un provider:
+
+
+```dart
+final counterProvider = StateProvider((ref) => 0);
+
+class HomeView extends ConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // use ref para escuchar a un provider
+    final counter = ref.watch(counterProvider).state;
+
+    return Text('$counter');
+  }
+}
+```
+
+:::caution PRECAUCIÓN
+El método `watch` no debe llamarse de forma asíncrona, como dentro de un `onPressed` de un [ElevatedButton]. 
+Tampoco se debe utilizar dentro `initState` u otro ciclo de vida del [State].
+
+En esos casos, considere usar `ref.read` en su lugar.
+:::
+
+### Uso de ref.listen para reaccionar ante un cambio
+
+De manera similar a `ref.watch`, es posible usar `ref.listen` para observar un provider.
+
+La principal diferencia entre ellos es que, en lugar de reconstruir el widget/provider 
+si el provider escuchado cambia, `ref.listen` llamará a una función personalizada.
+
+Eso puede ser útil para realizar acciones cuando ocurre un determinado cambio, como mostrar 
+un snackbar cuando ocurre un error.
+
+El método `ref.listen` necesita 2 argumentos posicionales, el primero es el provider y el segundo 
+es el callback que queremos ejecutar cuando cambia el estado. 
+Cuando se llame el callback, se pasarán 2 valores, el valor del Estado anterior y el valor del nuevo Estado.
+
+El método `ref.listen` se puede utilizar dentro del cuerpo de un provider:
+
+```dart
+final counterProvider = StateNotifierProvider<Counter, int>((ref) => Counter());
+
+final anotherProvider = Provider((ref) {
+  ref.listen<int>(counterProvider, (int? previousCount, int newCount) {
+    print('The counter changed ${newCount}');
+  });
+  ...
+});
+```
+
+o dentro del método `build` de un widget:
+
+```dart
+final counterProvider = StateNotifierProvider<Counter, int>((ref) => Counter());
+
+class HomeView extends ConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<int>(counterProvider, (int? previousCount, int newCount) {
+      print('The counter changed ${newCount}');
+    });
+    ...
+  }
+}
+```
+
+:::caution
+El método `listen` no debe llamarse de forma asíncrona, como dentro de un `onPressed` de un [ElevatedButton]. 
+Tampoco se debe utilizar dentro del `initState` u otro ciclo de vida del [State].
+:::
+
+### Uso de ref.read para obtener el estado de un provider una vez 
+
+El método `ref.read` es una forma de obtener el estado de un provider, sin ningún efecto extra.
+
+Se usa comúnmente dentro de las funciones desencadenadas por las interacciones del usuario. 
+Por ejemplo, podemos usar `ref.read` para incrementar un contador cuando un usuario hace clic en un botón:
+
+```dart
+final counterProvider = StateNotifierProvider<Counter, int>((ref) => Counter());
+
+class HomeView extends ConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // Llama a `increment()` de la clase `Counter`.
+          ref.read(counterProvider.notifier).increment();
+        },
+      ),
+    );
+  }
+}
+```
+
+:::note NOTA
+El uso de `ref.read` debe evitarse tanto como sea posible.
+
+Existe como una solución alternativa para los casos en los que usar `watch` o `listen` 
+sería demasiado inconveniente de usar.
+Si puede, casi siempre es mejor usar `watch`/`listen`, especialmente `watch`.
+:::
+
+#### **NO** usar `ref.read` dentro del método build
+
+Es posible que tenga la tentación de utilizar `ref.read` para optimizar el rendimiento 
+de un widget haciendo lo siguiente:
+
+
+```dart
+final counterProvider = StateProvider((ref) => 0);
+
+Widget build(BuildContext context, WidgetRef ref) {
+  // usar "read" para ignorar las actualizaciones de un provider
+  final counter = ref.read(counterProvider);
+  return ElevatedButton(
+    onPressed: () => counter.state++,
+  )
+}
+```
+Pero esta es una práctica muy mala y puede causar errores que son difíciles de rastrear.
+
+El uso de `ref.read` esta forma se asocia comúnmente con el pensamiento "El valor expuesto por 
+un provider nunca cambia, por lo que usar 'ref.read' es seguro". El problema con esta suposición 
+es que, si bien es posible que hoy ese provider nunca actualice su valor, no hay garantía de que mañana sea igual.
+
+El software tiende a cambiar mucho, y es probable que en el futuro, un valor que antes nunca cambiaba, tenga que cambiar.
+Pero si usó `ref.read`, cuando ese valor comienza a cambiar, tendría que revisar todo su código base para cambiar 
+`ref.read` en `ref.watch`, lo cual es propenso a errores y es probable que olvide algunos casos.
+
+Mientras que si usaras `ref.watch` al principio, no tendrías ningún problema.
+
+**_Pero quería usar `ref.read` para reducir la cantidad de veces que mi widget se reconstruye._**
+
+Si bien el objetivo es aplaudible, es importante tener en cuenta que puede lograr exactamente 
+el mismo efecto (reduciendo la cantidad de builds) usando `ref.watch` en su lugar.
+
+Los providers ofrecen varias formas de obtener un valor mientras reducen la cantidad de 
+reconstrucciones, que podría usar en su lugar.
+
+Por ejemplo en lugar de 
+
+```dart
+final counterProvider = StateProvider((ref) => 0);
+
+Widget build(BuildContext context, WidgetRef ref) {
+  StateController<int> counter = ref.read(counterProvider);
+  return ElevatedButton(
+    onPressed: () => counter.state++,
+  )
+}
+```
+
+podríamos hacer:
+
+```dart
+final counterProvider = StateProvider((ref) => 0);
+
+Widget build(BuildContext context, WidgetRef ref) {
+  StateController<int> counter = ref.watch(counterProvider.notifier);
+  return ElevatedButton(
+    onPressed: () => counter.state++,
+  )
+}
+```
+Ambos fragmentos de código logran el mismo efecto: nuestro botón no se reconstruirá cuando el contador aumente.
+
+Por otro lado, el segundo enfoque admite casos en los que se reinicia el contador. 
+Por ejemplo, otra parte de la aplicación podría llamar:
+
+```dart
+ref.refresh(counterProvider);
+```
+
+que recrearía el objeto `StateController`.
+
+Si usáramos `ref.read` aquí, nuestro botón seguiría usando la instancia anterior de `StateController`, 
+que se eliminó y ya no debería usarse. Mientras que usar `ref.watch` correctamente reconstruyó el botón 
+para usar el nuevo `StateController`.
+
+## Decidir qué leer
+
+Dependiendo del provider que desee escuchar, 
+puede tener varios valores posibles que puede escuchar.
+
+Como ejemplo, considere el siguiente [StreamProvider]:
+
+```dart
+final userProvider = StreamProvider<User>(...);
+```
+
+Al leer este `userProvider`, usted puede:
+
+- leer sincrónicamente el estado actual escuchándo de `userProvider`:
+
+  ```dart
+  Widget build(BuildContext context, WidgetRef ref) {
+    AsyncValue<User> user = ref.watch(userProvider);
+
+    return user.when(
+      loading: (_) => const CircularProgressIndicator(),
+      error: (error, stack, _) => const Text('Oops'),
+      data: (user) => Text(user.name),
+    );
+  }
+  ```
+- obtener el [Stream] asociado, escuchando `userProvider.stream`:
+  
+  ```dart
+  Widget build(BuildContext context, WidgetRef ref) {
+    Stream<User> user = ref.watch(userProvider.stream);
+  }
+  ```
+
+- obtener un [Future] que se resuelva con el último valor emitido, escuchando `userProvider.future`:
+  
+  ```dart
+  Widget build(BuildContext context, WidgetRef ref) {
+    Future<User> user = ref.watch(userProvider.last);
+  }
+  ```
+
+Otros providers pueden ofrecer diferentes valores alternativos.
+Para más información, consulte la documentación de cada provider consultando la 
+[referencia de la API](https://pub.dev/documentation/riverpod/latest/riverpod/riverpod-library.html).
+
+## Uso de "select" para filtrar reconstrucciones
+
+Una característica final a mencionar relacionada con la lectura de providers es 
+la capacidad de reducir la cantidad de veces que se reconstruye un widget/provider, o 
+con qué frecuencia `ref.listen` ejecuta una función.
+
+Es importante tener esto en cuenta ya que, de forma predeterminada, escuchar a un 
+provider escucha todo el objeto. Pero en algunos casos, es posible que un widget/provider 
+solo se preocupe por algunas propiedades en lugar del objeto completo.
+
+Por ejemplo, un provider puede exponer un `User`:
+
+```dart
+abstract class User {
+  String get name;
+  int get age;
+}
+```
+
+Pero un widget solo necesita usar la propiedad `name` del usuario:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  User user = ref.watch(userProvider);
+  return Text(user.name);
+}
+```
+
+Si usamos ingenuamente `ref.watch`, esto reconstruiría el widget cuando cambie la propiedad `age` del usuario.
+
+La solución es usar `select` para decirle explícitamente a Riverpod que solo queremos escuchar algunas propiedades de `User`.
+
+El código actualizado sería:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  String name = ref.watch(userProvider.select((user) => user.name))
+  return Text(name);
+}
+```
+
+La forma en que esto funciona al usar `select` es que estamos especificando una función 
+que devuelve la propiedad que nos interesa.
+
+Luego, cada vez que `User` cambie, Riverpod llamará a esta función y comparará el resultado 
+anterior y el nuevo. Si son diferentes (como cuando cambió la propiedad `name`), Riverpod reconstruirá el widget.
+Pero si son iguales (como cuando solo cambió la propiedad `age`), Riverpod no reconstruirá el widget.
+
+:::info
+También es posible utilizar `select` con `ref.listen`:
+
+```dart
+ref.listen<String>(
+  userProvider.select((user) => user.name),
+  (String? previousName, String newName) {
+    print('The user name changed $newName');
+  }
+);
+```
+Si lo hace, llamará al listener solo cuando cambie la propiedad `name`.
+:::
+
+:::tip
+No tienes que devolver una propiedad del objeto. 
+Cualquier valor que sobrescriba == funcionará.
+Por ejemplo podrías hacer:
+
+
+```dart
+final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
+```
+:::
+
+[provider]: https://pub.dev/documentation/riverpod/latest/riverpod/Provider-class.html
+[stateprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateProvider-class.html
+[providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
+[providerlistener]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderListener-class.html
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[consumer]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Consumer-class.html
+[consumerwidget]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerWidget-class.html
+[consumerstate]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerStatefulWidget-class.html
+[consumerstatefulwidget]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerState-class.html
+[useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
+[elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
+[streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
+[riverpod]: https://github.com/rrousselgit/river_pod
+[text]: https://api.flutter.dev/flutter/widgets/Text-class.html
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html
+[stream]: https://api.dart.dev/stable/2.13.4/dart-async/Stream-class.html
+[hookwidget]: https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/HookWidget-class.html
+[hookconsumerwidget]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/HookConsumerWidget-class.html
+[hookconsumer]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/HookConsumer-class.html
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[statenotifierprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateNotifierProvider-class.html
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[streamprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StreamProvider-class.html
+[statelesswidget]: https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html
+[statefulwidget]: https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html
+[state]: https://api.flutter.dev/flutter/widgets/State-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -1,0 +1,425 @@
+---
+title: Testing
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Para cualquier aplicación de mediana a gran escala, es fundamental hacer pruebas a la aplicación.
+
+Para testear con éxito nuestra aplicación, necesitaremos lo siguiente:
+
+- No se debe conservar ningún estado entre `test`/`testWidgets`. 
+  Eso significa que no hay estado global en la aplicación, o todos los estados globales 
+  deben restablecerse después de cada test.
+
+- Siendo capaces de forzar a nuestros providers a tener un estado determinado, 
+  ya sea mediante "mocks" o manipulándolos hasta llegar al estado deseado.
+
+Veamos uno por uno cómo [Riverpod] te ayuda con esto.
+
+## No se debe conservar ningún estado entre `test`/`testWidgets`. 
+
+Dado que los providers generalmente se declaran como variables globales, 
+es posible que te preocupes por eso. Después de todo, 
+el estado global hace que los test sean muy difíciles, 
+ya que puede requerir un `setUp`/`tearDown` bastante largo.
+
+Pero la realidad es: mientras que los providers se declaran como globales, 
+el estado de un provider **no** es global.
+
+En su lugar, se almacena en un objeto llamado [ProviderContainer], 
+que puede haber visto si revisó los ejemplos de Solo Dart.
+Si no lo ha hecho, sepa que este objeto [ProviderContainer] lo crea implícitamente 
+el [ProviderScope], widget que habilita [Riverpod] en nuestro proyecto.
+
+Concretamente, lo que esto significa es que dos `testWidgets` que usan providers no 
+comparten ningún estado. Como tal, no hay necesidad de `setUp`/`tearDown` en absoluto. 
+
+Pero un ejemplo es mejor que largas explicaciones:
+
+<Tabs
+  defaultValue="testWidgets"
+  values={[
+    { label: 'testWidgets (Flutter)', value: 'testWidgets', },
+    { label: 'test (Solo Dart)', value: 'test', },
+  ]}
+>
+<TabItem value="testWidgets">
+
+```dart
+// Un Contador implementado y testeado usando Flutter
+
+// Declaramos un provider globalmente, y lo usaremos en dos test, para ver 
+// si el estado se restablece correctamente a `0` entre los test.
+final counterProvider = StateProvider((ref) => 0);
+
+// Representa el estado actual y un botón que permite incrementar el estado
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Consumer(builder: (context, ref, _) {
+        final counter = ref.watch(counterProvider);
+        return RaisedButton(
+          onPressed: () => ref.read(counterProvider.notifier).state++,
+          child: Text('${counter.state}'),
+        );
+      }),
+    );
+  }
+}
+
+void main() {
+  testWidgets('update the UI when incrementing the state', (tester) async {
+    await tester.pumpWidget(ProviderScope(child: MyApp()));
+
+    // El valor por defecto es `0`, tal como lo declara nuestro provider
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Incrementar el estado y volver a renderizar
+    await tester.tap(find.byType(RaisedButton));
+    await tester.pump();
+
+    // El estado ha incrementado adecuadamente
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('0'), findsNothing);
+  });
+
+  testWidgets('the counter state is not shared between tests', (tester) async {
+    await tester.pumpWidget(ProviderScope(child: MyApp()));
+
+    // El estado es `0` una vez más, sin necesidad de tearDown/setUp
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+  });
+}
+```
+
+</TabItem>
+<TabItem value="test">
+
+```dart
+// Un contador implementado y testeado solo con Dart (sin dependencia de Flutter)
+
+// Declaramos un provider globalmente, y lo usaremos en dos test, para ver 
+// si el estado se restablece correctamente a `0` entre los test.
+
+final counterProvider = StateProvider((ref) => 0);
+
+// Usando mockito para realizar un seguimiento de cuándo un provider notifica a sus listeners (oyentes)
+class Listener extends Mock {
+  void call(int? previous, int value);
+}
+
+void main() {
+  test('defaults to 0 and notify listeners when value changes', () {
+    // Un objeto que nos permitirá leer providers 
+    // No comparta esto entre pruebas.
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final listener = Listener();
+
+    // Observar un provider y espiar los cambios.
+    container.listen<int>(
+      counterProvider,
+      listener,
+      fireImmediately: true,
+    );
+
+    // el listener es llamado inmediatamente con 0, el valor por defecto
+    verify(listener(null, 0)).called(1);
+    verifyNoMoreInteractions(listener);
+
+    // Incrementamos el valor
+    container.read(counterProvider.notifier).state++;
+
+    // Se volvió a llamar al listener, pero esta vez con 1
+    verify(listener(0, 1)).called(1);
+    verifyNoMoreInteractions(listener);
+  });
+
+  test('the counter state is not shared between tests', () {
+    // Usamos un ProviderContainer diferente para leer nuestro provider. 
+    // Esto asegura que no se reutilice ningún estado entre pruebas
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final listener = Listener();
+
+    container.listen<int>(
+      counterProvider,
+      listener,
+      fireImmediately: true,
+    );
+
+    // Le compteur est à nouveau à 0
+    verify(listener(null, 0)).called(1);
+    verifyNoMoreInteractions(listener);
+  });
+}
+```
+
+</TabItem>
+</Tabs>
+
+Como puede ver, aunque `counterProvider` se declaró como global, 
+no se compartió ningún estado entre los test.
+Como tal, no tenemos que preocuparnos de que nuestros test se 
+comporten de manera diferente si se ejecutan en un orden diferente, 
+ya que se ejecutan de forma completamente aislada.
+
+## Sobrescribir el comportamiento de un provider durante los test.
+
+Una aplicación común del mundo real puede tener los siguientes objetos:
+
+- Una clase `Repository`, que proporciona una API simple y segura 
+  para realizar solicitudes HTTP.
+
+- Un objeto que administra el estado de la aplicación y puede usar 
+  el `Repository` para realizar solicitudes HTTP en función de diferentes factores. 
+  Esto puede ser un `ChangeNotifier`, `Bloc` o incluso un provider.
+
+Usando [Riverpod], esto se puede representar de la siguiente manera:
+
+```dart
+class Repository {
+  Future<List<Todo>> fetchTodos() async {}
+}
+
+// Exponemos nuestra instancia de Repository en un provider
+final repositoryProvider = Provider((ref) => Repository());
+
+/// La lista de tareas. Aquí, simplemente los estamos obteniendo del servidor usando
+/// [Repository] y no haciendo nada más.
+final todoListProvider = FutureProvider((ref) async {
+  // Obtiene la instancia de Repository
+  final repository = ref.read(repositoryProvider);
+
+  // Obtenga las tareas y expóngalos a la interfaz de usuario.
+  return repository.fetchTodos();
+});
+```
+
+En esta situación, al realizar un test unitario o de widget, normalmente querremos 
+reemplazar nuestra instancia de `Repository` con una implementación falsa que devuelva 
+una respuesta predefinida en lugar de realizar una solicitud HTTP real.
+
+Entonces querremos que nuestro todoListProvider o equivalente use la implementación simulada de `Repository`.
+
+Para lograr esto, podemos usar el parámetro `overrides` de [ProviderScope]/[ProviderContainer] 
+para sobrescribir el comportamiento de `repositoryProvider`:
+
+<Tabs
+  defaultValue="ProviderScope"
+  values={[
+    { label: 'ProviderScope (Flutter)', value: 'ProviderScope', },
+    { label: 'ProviderContainer (Solo Dart)', value: 'ProviderContainer', },
+  ]}
+>
+<TabItem value="ProviderScope">
+
+```dart {7}
+testWidgets('override repositoryProvider', (tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        // Sobrescribir el comportamiento de repositoryProvider para devolver 
+        // FakeRepository en lugar de Repository.
+        repositoryProvider.overrideWithValue(FakeRepository())
+        // No tenemos que sobrescribir `todoListProvider`,
+        // automáticamente usara el repositoryProvider sobrescrito
+      ],
+      child: MyApp(),
+    ),
+  );
+}
+```
+
+</TabItem>
+<TabItem value="ProviderContainer">
+
+```dart {6}
+test('override repositoryProvider', () async {
+  final container = ProviderContainer(
+    overrides: [
+        // Sobrescribir el comportamiento de repositoryProvider para devolver 
+        // FakeRepository en lugar de Repository.
+        repositoryProvider.overrideWithValue(FakeRepository())
+        // No tenemos que sobrescribir `todoListProvider`,
+        // automáticamente usara el repositoryProvider sobrescrito
+    ],
+  );
+
+  // La primera lectura si es un estado de carga
+  expect(
+    container.read(todoListProvider),
+    const AsyncValue<List<Todo>>.loading(),
+  );
+
+  /// Espere a que termine la solicitud
+  await container.read(todoListProvider.future);
+
+  // Expone los datos obtenidos
+  expect(container.read(todoListProvider).value, [
+    isA<Todo>()
+        .having((s) => s.id, 'id', '42')
+        .having((s) => s.label, 'label', 'Hello world')
+        .having((s) => s.completed, 'completed', false),
+  ]);
+});
+```
+
+</TabItem>
+</Tabs>
+
+Como puedes ver en el código resaltado, [ProviderScope]/[ProviderContainer] permite 
+reemplazar la implementación de un provider con un comportamiento diferente.
+
+:::info
+Algunos providers exponen formas simplificadas de sobrescribir su comportamiento. 
+Por ejemplo, [FutureProvider] permite sobrescribir el provider con un `AsyncValue`:
+
+```dart
+final todoListProvider = FutureProvider((ref) async => <Todo>[]);
+// ...
+ProviderScope(
+  overrides: [
+    /// Permite sobrescribir un FutureProvider para devolver un valor fijo
+    todoListProvider.debugOverrideWithValue(
+      AsyncValue.data([Todo(id: '42', label: 'Hello', completed: true)]),
+    ),
+  ],
+  child: MyApp(),
+);
+```
+
+:::
+
+:::info
+La sintaxis para sobrescribir un provider con el modificador de `family` es ligeramente diferente.
+
+Si usó un provider como este:
+
+```dart
+final response = ref.watch(myProvider('12345'));
+```
+
+Puede sobrescribir el provider como:
+
+```dart
+myProvider('12345').overrideWithValue(...));
+```
+
+:::
+
+## Ejemplo completo del test de widget 
+
+Para concluir, aquí está el código completo completo para nuestra prueba de Flutter.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class Repository {
+  Future<List<Todo>> fetchTodos() async {}
+}
+
+class Todo {
+  Todo({
+    required this.id,
+    required this.label,
+    required this.completed,
+  });
+
+  final String id;
+  final String label;
+  final bool completed;
+}
+
+// Exponemos nuestra instancia de Repository en un provider
+final repositoryProvider = Provider((ref) => Repository());
+
+/// La lista de tareas. Aquí, simplemente los estamos obteniendo del servidor usando 
+/// [ReposiRepositorytorio] y no hacemos nada más.
+final todoListProvider = FutureProvider((ref) async {
+  // Obtiene la instancia del Repository
+  final repository = ref.read(repositoryProvider);
+
+  // Obtenga las tareas y expóngalos a la interfaz de usuario.
+  return repository.fetchTodos();
+});
+
+/// Una implementación simulada de Repository que devuelve una lista predefinida de tareas
+class FakeRepository implements Repository {
+  @override
+  Future<List<Todo>> fetchTodos() async {
+    return [
+      Todo(id: '42', label: 'Hello world', completed: false),
+    ];
+  }
+}
+
+class TodoItem extends StatelessWidget {
+  const TodoItem({Key? key, required this.todo}) : super(key: key);
+  final Todo todo;
+  @override
+  Widget build(BuildContext context) {
+    return Text(todo.label);
+  }
+}
+
+void main() {
+  testWidgets('override repositoryProvider', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          repositoryProvider.overrideWithValue(FakeRepository())
+        ],
+        // Nuestra aplicación, que leerá desde todoListProvider para mostrar la lista de tareas pendientes.
+        // Probablemente extraigas esto en un widget de MyApp
+        child: MaterialApp(
+          home: Scaffold(
+            body: Consumer(builder: (context, ref, _) {
+              final todos = ref.watch(todoListProvider);
+              // La lista de tareas está cargando o en error
+              if (todos.data == null) {
+                return const CircularProgressIndicator();
+              }
+              return ListView(
+                children: [
+                  for (final todo in todos.data.value) TodoItem(todo: todo)
+                ],
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+
+    // El primer frame es un estado de carga.
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    // Re-renderiza. TodoListProvider ya debería haber obtener todos las tareas.
+    await tester.pump();
+
+    // Sin estado de carga.
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    
+    // Renderizó una tarea con los datos devueltos por FakeRepository
+    expect(tester.widgetList(find.byType(TodoItem)), [
+      isA<TodoItem>()
+          .having((s) => s.todo.id, 'todo.id', '42')
+          .having((s) => s.todo.label, 'todo.label', 'Hello world')
+          .having((s) => s.todo.completed, 'todo.completed', false),
+    ]);
+  });
+}
+```
+
+[riverpod]: https://github.com/rrousselgit/river_pod
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
+[futureprovider]: ../providers/future_provider
+[zone]: https://api.flutter.dev/flutter/dart-async/Zone-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -1,0 +1,225 @@
+---
+title: Empezando
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+Antes de sumergirnos en los mecanismos internos de [Riverpod], comencemos con 
+lo básico: instalar [Riverpod] y luego escribir un "Hello world".
+
+## Qué paquete instalar
+
+Antes que nada, debes tener en cuenta que [Riverpod] se distribuye en varios paquetes con un uso ligeramente diferente.
+La variante de [Riverpod] a instalar depende de la aplicación que vas a desarrollar.
+
+Puedes consultar la siguiente tabla para decidir qué paquete usar:
+
+| Tipo de aplicación             | Nombre del paquete                                                                 | Descripción                                                    |
+| ------------------------------ | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Flutter + [flutter_hooks]      | [hooks_riverpod]                                                                   | Permite usar [flutter_hooks] y [Riverpod] juntos.              |
+| Solo Flutter                   | [flutter_riverpod]                                                                 | Una forma básica de usar [Riverpod] para aplicaciones Flutter. |
+| Solo Dart (Sin Flutter)        | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | [Riverpod] sin todas las clases dependientes de Flutter.       |
+
+## Instalación
+
+Una vez que sepas qué paquete deseas instalar, procede a añadir lo siguiente a tu `pubspec.yaml`:
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="hooks_riverpod"
+  values={[
+    { label: 'Flutter + flutter_hooks', value: 'hooks_riverpod', },
+    { label: 'Flutter', value: 'flutter_riverpod', },
+    { label: 'Solo Dart', value: 'riverpod', },
+  ]}
+>
+<TabItem value="hooks_riverpod">
+
+```yaml title="pubspec.yaml"
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_hooks: ^0.18.0
+  hooks_riverpod: ^2.0.0-dev.0
+```
+
+Luego ejecuta `flutter pub get`.
+
+</TabItem>
+<TabItem value="flutter_riverpod">
+
+```yaml title="pubspec.yaml"
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.0.0-dev.0
+```
+
+Luego ejecuta `flutter pub get`.
+
+</TabItem>
+<TabItem value="riverpod">
+
+```yaml title="pubspec.yaml"
+environment:
+  sdk: ">=2.12.0-0 <3.0.0"
+
+dependencies:
+  riverpod: ^2.0.0-dev.0
+```
+
+Luego ejecuta `dart pub get`.
+
+</TabItem>
+</Tabs>
+
+Eso es todo. ¡Lograste añadir [Riverpod] a tu aplicación!
+
+## Ejemplo de uso: Hello world
+
+Ahora que hemos instalado [Riverpod], podemos comenzar a usarlo.
+
+Los siguientes fragmentos de código muestran cómo usar nuestra nueva dependencia para crear un "Hello world":
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="hooks_riverpod"
+  values={[
+    { label: "Flutter + flutter_hooks", value: "hooks_riverpod" },
+    { label: "Flutter", value: "flutter_riverpod" },
+    { label: "Solo Dart", value: "riverpod" },
+  ]}
+>
+<TabItem value="hooks_riverpod">
+
+```dart title="lib/main.dart"
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// Creamos un "provider", el cual almacenará un valor (en este caso "Hello world").
+// El usar un provider nos permitirá simular/sobrescribir el valor expuesto.
+final helloWorldProvider = Provider((_) => 'Hello world');
+
+void main() {
+  runApp(
+    // Para que los widgets puedan leer los providers, necesitamos envolver
+    // toda la aplicación en un `ProviderScope`.
+    // Aquí es donde se almacenará el estado de nuestros providers.
+    ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+
+// Nota: MyApp es un HookConsumerWidget de flutter_hooks.
+class MyApp extends HookConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final String value = ref.watch(helloWorldProvider);
+
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: Text('Example')),
+        body: Center(
+          child: Text(value),
+        ),
+      ),
+    );
+  }
+}
+```
+
+Que luego puedes ejecutar con `flutter run`.
+Esto mostrará un "Hello world" en tu dispositivo.
+
+</TabItem>
+<TabItem value="flutter_riverpod">
+
+```dart title="lib/main.dart"
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+// Creamos un "provider", el cual almacenará un valor (aquí "Hello world").
+// El usar un provider nos permitirá simular/sobrescribir el valor expuesto.
+final helloWorldProvider = Provider((_) => 'Hello world');
+
+void main() {
+  runApp(
+    // Para que los widgets puedan leer los providers, necesitamos envolver
+    // toda la aplicación en un "ProviderScope".
+    // Aquí es donde se almacenará el estado de nuestros providers.
+    ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+
+// Extienda de un ConsumerWidget (expuesto por Riverpod) en lugar de un StatelessWidget.
+class MyApp extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final String value = ref.watch(helloWorldProvider);
+
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: Text('Example')),
+        body: Center(
+          child: Text(value),
+        ),
+      ),
+    );
+  }
+}
+```
+
+Que luego puedes ejecutar con `flutter run`.
+Esto mostrará un "Hello world" en tu dispositivo.
+
+</TabItem>
+<TabItem value="riverpod">
+
+```dart title="lib/main.dart"
+import 'package:riverpod/riverpod.dart';
+
+// Creamos un "provider", el cual almacenará un valor (aquí "Hello world").
+// El usar un provider nos permitirá simular/sobrescribir el valor expuesto.
+final helloWorldProvider = Provider((_) => 'Hello world');
+
+void main() {
+  // En este objeto es donde se almacenará el estado de nuestros providers.
+  final container = ProviderContainer();
+
+  // Gracias al "container", podemos leer nuestro provider.
+  final value = container.read(helloWorldProvider);
+
+  print(value); // Hello world
+}
+```
+
+Que luego puedes ejecutar con `dart lib/main.dart`.
+Esto mostrará un "Hello world" en la consola.
+
+</TabItem> 
+</Tabs>
+
+## Mejora tu productividad: Instala los atajos de código
+
+Si usas `Flutter` y `VS Code`, considera usar [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets).
+
+Si usas `Flutter` y `Android Studio` o `IntelliJ`, considera usar [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets).
+
+![img](/img/snippets/greetingProvider.gif)
+
+[riverpod]: https://github.com/rrousselgit/river_pod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -1,0 +1,118 @@
+---
+title: ^0.13.0 a ^0.14.0
+---
+
+Con el lanzamiento de la versión `0.14.0` de Riverpod, la sintaxis para usar [StateNotifierProvider] cambió
+(ve a https://github.com/rrousseGit/river_pod/issues/341 por la explicación).
+
+
+Para ver todo el artículo, considere el siguiente [StateNotifier]:
+
+```dart
+class MyModel {}
+
+class MyStateNotifier extends StateNotifier<MyModel> {
+  MyStateNotifier(): super(MyModel());
+}
+```
+
+## Los cambios
+- [StateNotifierProvider] toma un parámetro genérico adicional que debe ser del tipo de estado de tu [StateNotifier].
+
+  Antes:
+
+  ```dart
+  final provider = StateNotifierProvider<MyStateNotifier>((ref) {
+    return MyStateNotifier();
+  });
+  ```
+
+  Después:
+
+  ```dart
+  final provider = StateNotifierProvider<MyStateNotifier, MyModel>((ref) {
+    return MyStateNotifier();
+  });
+  ```
+
+- para obtener el [StateNotifier], ahora debes leer `myProvider.notifier` en lugar de solo `myProvider`:
+
+  Antes:    
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyStateNotifier notifier = watch(provider);
+  }
+  ```
+
+  Después:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyStateNotifier notifier = watch(provider.notifier);
+  }
+  ```
+
+- para escuchar el estado de [StateNotifier], ahora debes leer `myProvider` en lugar de `myProvider.state`:
+
+  Antes:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyModel state = watch(provider.state);
+  }
+  ```
+
+  Después:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyModel state = watch(provider);
+  }
+  ```
+
+## Usando la herramienta de migración para actualizar automáticamente tus proyectos a la nueva sintaxis
+
+Con la versión 0.14.0 llegó el lanzamiento de una herramienta de línea de comandos para Riverpod que puede ayudarte a migrar tus proyectos.
+
+### Instalación de la línea de comandos
+
+Para instalar la herramienta de migración, ejecuta:
+
+```sh
+dart pub global activate riverpod_cli
+```
+
+Ahora deberías poder ejecutar:
+
+```dart
+riverpod --help
+```
+
+### Uso
+
+Ahora que la línea de comandos está instalada, podemos comenzar a usarla.
+
+- Primero, abre el proyecto que desea migrar en tu terminal.
+- **No** actualices Riverpod.
+- La herramienta de migración actualizará la versión de Riverpod por usted.
+- Asegúrese de que su proyecto no contenga errores.
+- Ejecutar:
+  ```sh
+  riverpod migrate
+  ```
+La herramienta luego analizará su proyecto y sugerirá cambios. Por ejemplo, puedes ver:
+
+```diff
+Widget build(BuildContext context, ScopedReader watch) {
+-  MyModel state = watch(provider.state);
++  MyModel state = watch(provider);
+}
+
+Accept change (y = yes, n = no [default], A = yes to all, q = quit)? 
+```
+
+Para aceptar el cambio, simplemente presione <kbd>y</kbd>. De lo contrario, para rechazarlo, presione <kbd>n</kbd>.
+
+[statenotifierprovider]: ../providers/state_notifier_provider
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
@@ -1,0 +1,221 @@
+---
+title: ^0.14.0 a ^1.0.0
+---
+
+Después de una larga espera, finalmente se lanzó la primera versión estable de Riverpod 👏
+
+Para ver la lista completa de cambios, consulte el [registro de cambios](https://pub.dev/packages/flutter_riverpod/changelog#100).
+En esta página, nos centraremos en cómo migrar una aplicación Riverpod existente de la versión 0.14.x a la versión 1.0.0.
+
+## Usando la herramienta de migración para actualizar automáticamente tu proyecto a la nueva sintaxis
+
+Antes de explicar los diversos cambios, vale la pena señalar que Riverpod viene con una herramienta de línea de comandos para migrar automáticamente su proyecto por usted.
+
+### Instalación de la línea de comandos
+
+Para instalar la herramienta de migración, ejecuta:
+
+```sh
+dart pub global activate riverpod_cli
+```
+
+Ahora deberías poder ejecutar:
+
+```dart
+riverpod --help
+```
+
+### Uso
+
+Ahora que la línea de comando está instalada, podemos comenzar a usarla.
+
+- Primero, abre el proyecto que desea migrar en su terminal.
+- **No** actualices Riverpod.
+  La herramienta de migración actualizará la versión de Riverpod por usted.
+  :::danger Advertencia
+  No actualizar Riverpod es importante.
+  La herramienta no se ejecutará correctamente si ya ha instalado la versión 1.0.0.
+  Como tal, asegúrese de estar utilizando correctamente una versión anterior antes de iniciar la herramienta.
+  :::
+
+- Asegúrese de que su proyecto no contenga errores.
+- Ejecuta:
+  ```sh
+  riverpod migrate
+  ```
+
+La herramienta luego analizará su proyecto y sugerirá cambios. Por ejemplo, puedes ver:
+
+```diff
+-Widget build(BuildContext context, ScopedReader watch) {
++Widget build(BuildContext context, Widget ref) {
+-  MyModel state = watch(provider);
++  MyModel state = ref.watch(provider);
+}
+
+Accept change (y = yes, n = no [default], A = yes to all, q = quit)?
+```
+
+Para aceptar el cambio, simplemente presione <kbd>y</kbd>. De lo contrario, para rechazarlo, presione <kbd>n</kbd>.
+
+## Los cambios
+
+Ahora que hemos visto cómo usar la CLI para actualizar automáticamente tu proyecto, veamos en detalle los cambios necesarios.
+
+### Unificación de sintaxis
+
+La versión 1.0.0 de Riverpod se centró en la unificación de la sintaxis para interactuar con los providers.
+Antes, Riverpod tenía muchas sintaxis similares pero aún diferentes para leer un provider, como `ref.watch(provider)` vs `useProvider(provider)` vs `watch(provider)`.
+Con la versión 1.0.0, solo queda una sintaxis: `ref.watch(provider)`. Las demás fueron eliminadas.
+
+Como:
+
+- `useProvider` se elimina a favor de `HookConsumerWidget`.
+
+  Antes:
+
+  ```dart
+  class Example extends HookWidget {
+    @override
+    Widget build(BuildContext context) {
+      useState(...);
+      int count = useProvider(counterProvider);
+      ...
+    }
+  }
+  ```
+
+  Después:
+
+  ```dart
+  class Example extends HookConsumerWidget {
+    @override
+    Widget build(BuildContext context, WidgetRef ref) {
+      useState(...);
+      int count = ref.watch(counterProvider);
+      ...
+    }
+  }
+  ```
+
+- Se cambia el prototipo del método `build` del `ConsumerWidget` y el método `builder` del `Consumer`.
+
+  Antes:
+
+  ```dart
+  class Example extends ConsumerWidget {
+    @override
+    Widget build(BuildContext context, ScopedReader watch) {
+      int count = watch(counterProvider);
+      ...
+    }
+  }
+
+  Consumer(
+    builder: (context, watch, child) {
+      int count = watch(counterProvider);
+      ...
+    }
+  )
+  ```
+
+  Después:
+
+  ```dart
+  class Example extends ConsumerWidget {
+    @override
+    Widget build(BuildContext context, WidgetRef ref) {
+      int count = ref.watch(counterProvider);
+      ...
+    }
+  }
+
+  Consumer(
+    builder: (context, ref, child) {
+      int count = ref.watch(counterProvider);
+      ...
+    }
+  )
+  ```
+
+- `context.read` se elimina en favor de `ref.read`.
+
+  Antes:
+
+  ```dart
+  class Example extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      SomeButton(
+        onPressed: () => context.read(provider.notifier).doSomething(),
+      );
+    }
+  }
+  ```
+
+  Después:
+
+  ```dart
+  class Example extends ConsumerWidget {
+    @override
+    Widget build(BuildContext context, WidgetRef ref) {
+      SomeButton(
+        onPressed: () => ref.read(provider.notifier).doSomething(),
+      );
+    }
+  }
+  ```
+
+### Actualización de StateProvider
+
+[StateProvider] se actualizó para coincidir con [StateNotifierProvider].
+
+Antes, hacer `ref.watch(StateProvider)` devolvía una instancia de `StateController`. Ahora solo devuelve el estado del `StateController`.
+
+Para migrar tienes algunas soluciones.
+Si tu código solo obtuvo el estado sin modificarlo, puedes cambiar 
+
+De:
+
+```dart
+final provider = StateProvider<int>(...);
+
+Consumer(
+  builder: (context, ref, child) {
+    StateController<int> count = ref.watch(provider);
+
+    return Text('${count.state}');
+  }
+)
+```
+
+a:
+
+```dart
+final provider = StateProvider<int>(...);
+
+Consumer(
+  builder: (context, ref, child) {
+    int count = ref.watch(provider);
+
+    return Text('${count}');
+  }
+)
+```
+Alternativamente, puede usar el nuevo `StateProvider.state` para mantener el comportamiento anterior.
+
+```dart
+final provider = StateProvider<int>(...);
+
+Consumer(
+  builder: (context, ref, child) {
+    StateController<int> count = ref.watch(provider.state);
+
+    return Text('${count.state}');
+  }
+)
+```
+
+[statenotifierprovider]: ../providers/state_notifier_provider
+[stateprovider]: ../providers/state_provider
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/future_provider.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/future_provider.mdx
@@ -1,0 +1,53 @@
+---
+title: FutureProvider
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import configProvider from "!!raw-loader!/i18n/ja/docusaurus-plugin-content-docs/current/providers/future_provider/config_provider.dart";
+import configConsumer from "!!raw-loader!/i18n/ja/docusaurus-plugin-content-docs/current/providers/future_provider/config_consumer.dart";
+import { trimSnippet } from "../../../../../src/components/CodeSnippet";
+
+`FutureProvider` es el equivalente de [Provider] pero para código asíncrono.
+
+`FutureProvider` se usa típicamente para:
+
+- realizar y almacenar en caché operaciones asíncronas (como solicitudes de red) 
+- manejar bien los estados de error/carga de las operaciones asincrónicas 
+- combinar múltiples valores asíncronos en otro valor
+
+`FutureProvider` va muy bien cuando se combina con [ref.watch]. Esta combinación permite la recuperación automática 
+de algunos datos cuando cambian algunas variables, lo que garantiza que siempre tengamos el valor más actualizado.
+
+:::info
+`FutureProvider` no ofrece una forma de modificar directamente el cálculo después de una interacción del usuario. 
+Está diseñado para resolver casos de uso simples. Para escenarios más avanzados, considere usar StateNotifierProvider.
+:::
+
+## Ejemplo de uso: leer un archivo de configuración
+
+`FutureProvider` puede ser una forma conveniente de exponer un objeto `Configuration`  
+creado mediante la lectura de un archivo JSON.
+
+La creación de la configuración se haría con la sintaxis típica de async/await, pero dentro del provider. 
+Usando el sistema de assets de Flutter, esto sería:
+
+<CodeBlock>{trimSnippet(configProvider)}</CodeBlock>
+
+Luego, la interfaz de usuario puede escuchar configuraciones como esta:
+
+<CodeBlock>{trimSnippet(configConsumer)}</CodeBlock>
+
+Esto reconstruirá automáticamente la interfaz de usuario cuando se complete el [Future]. 
+Al mismo tiempo, si varios widgets desean las configuraciones, el asset se decodificará solo una vez.
+
+Como puedes ver, escuchar un `FutureProvider` dentro de un widget devuelve un [AsyncValue], 
+que permite manejar los estados de error/carga.
+
+[ref.watch]: ../concepts/reading#uso-de-refwatch-para-observar-a-un-provider
+[statenotifierprovider]: ./state_notifier_provider
+[provider]: ./provider
+[asyncvalue]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue-class.html
+[future]: https://api.dart.dev/dart-async/Future-class.html
+[family]: ../concepts/modifiers/family

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/future_provider/config_consumer.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/future_provider/config_consumer.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'config_provider.dart';
+
+/* SNIPPET START */
+
+Widget build(BuildContext context, WidgetRef ref) {
+  AsyncValue<Configuration> config = ref.watch(configProvider);
+
+  return config.when(
+    loading: () => const CircularProgressIndicator(),
+    error: (err, stack) => Text('Error: $err'),
+    data: (config) {
+      return Text(config.host);
+    },
+  );
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/future_provider/config_provider.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/future_provider/config_provider.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: avoid_unused_constructor_parameters
+
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class Configuration {
+  Configuration.fromJson(Map<String, Object?> json);
+
+  final String host = '';
+}
+
+/* SNIPPET START */
+
+final configProvider = FutureProvider<Configuration>((ref) async {
+  final content = json.decode(
+    await rootBundle.loadString('assets/configurations.json'),
+  ) as Map<String, Object?>;
+
+  return Configuration.fromJson(content);
+});

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider.mdx
@@ -1,0 +1,96 @@
+---
+title: Provider
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import todo from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/todo.dart";
+import completedTodos from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/completed_todos.dart";
+import unoptimizedPreviousButton from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart";
+import optimizedPreviousButton from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart";
+import { trimSnippet } from "../../../../../src/components/CodeSnippet";
+
+`Provider` es el más básico de todos los providers. Crea un valor... Y eso es todo.
+
+`Provider` se utiliza típicamente para:
+
+- almacenamiento de cálculos en caché 
+- exponer un valor a otros providers (como un `Repository`/`HttpClient`).
+- ofreciendo una forma para testear o que los widgets sobrescriban un valor.
+- reduciendo las reconstrucciones de providers/widgets sin tener que usar `select`.
+
+## Uso de `Provider` para almacenar los cálculos en caché 
+
+`Provider` es una poderosa herramienta para almacenar en caché 
+operaciones sincrónicas cuando se combina con [ref.watch].
+
+Un ejemplo sería filtrar una lista de tareas. Dado que filtrar una lista puede ser un poco costoso, 
+idealmente no queremos filtrar nuestra lista de tareas cada vez que nuestra aplicación se vuelve a 
+renderizar. En esta situación, podríamos usar `Provider` para hacer el filtrado por nosotros.
+
+Para eso, suponga que nuestra aplicación tiene un [StateNotifierProvider] 
+existente que manipula una lista de tareas:
+
+<CodeBlock>{trimSnippet(todo)}</CodeBlock>
+
+A partir de ahí, podemos usar `Provider` para exponer la lista filtrada de tareas, 
+mostrando solo las tareas completadas:
+
+<CodeBlock>{trimSnippet(completedTodos)}</CodeBlock>
+
+Con este código, nuestra interfaz de usuario ahora puede mostrar la lista de 
+tareas completados al escuchar `completedTodosProvider`:
+
+```dart
+Consumer(builder: (context, ref, child) {
+  final completedTodos = ref.watch(completedTodosProvider);
+  // TODO: mostrar la lista de tareas (todos) en un ListView/GridView/...
+});
+```
+
+La parte interesante es que el filtrado de listas ahora está en caché.
+
+Lo que significa que la lista de tareas completados no se volverá a calcular hasta que se 
+agreguen/eliminen/actualicen tareas, incluso si estamos leyendo la lista de tareas completadas varias veces.
+
+Tenga en cuenta que no necesitamos invalidar manualmente el caché cuando cambia la lista de tareas. 
+`Provider` es capaz de saber automáticamente cuándo se debe volver a calcular el resultado gracias a [ref.watch].
+
+## Reducción de reconstrucciones de widgets/providers mediante el uso de `Provider`
+
+Un aspecto único de `Provider` es que incluso cuando se vuelve a calcular `Provider` 
+(normalmente cuando se usa [ref.watch]), no actualizará los widgets/providers que lo escuchan 
+a menos que cambie el valor.
+
+Un ejemplo del mundo real sería habilitar/deshabilitar los botones anterior/siguiente de una vista paginada:
+
+![Botón "Atrás/Siguiente"](https://user-images.githubusercontent.com/134939/47580830-31263a00-d950-11e8-9b61-0eaddab2709e.png)
+
+En nuestro caso, nos centraremos concretamente en el botón "anterior".
+Una implementación ingenua de dicho botón sería un widget que obtiene el índice de la página actual,
+y si ese índice es igual a 0, deshabilitaríamos el botón.
+
+Este código podría ser:
+
+<CodeBlock>{trimSnippet(unoptimizedPreviousButton)}</CodeBlock>
+
+El problema con este código es que cada vez que cambiamos la página actual, el botón "anterior" se reconstruirá.
+En el mundo ideal, querríamos que el botón se reconstruya solo cuando cambie entre activado y desactivado.
+
+La raíz del problema aquí es que estamos calculando si el usuario puede ir a la página anterior directamente desde el botón "anterior".
+
+Una forma de resolver esto es extraer esta lógica fuera del widget y en un `Provider`:
+
+<CodeBlock>{trimSnippet(optimizedPreviousButton)}</CodeBlock>
+
+Al hacer esta pequeña refactorización, nuestro widget `PreviousButton` ya no se reconstruirá cuando 
+el índice de la página cambie gracias a `Provider`.
+
+A partir de ahora, cuando cambie el índice de la página, `canGoToPreviousPageProvider` se volverá a 
+calcular. Pero si el valor expuesto por el provider no cambia, entonces `PreviousButton` no se reconstruirá.
+
+Este cambio mejoró el rendimiento de nuestro botón y tuvo el beneficio interesante de extraer la lógica fuera de nuestro widget.
+
+[ref.watch]: ../concepts/reading#uso-de-refwatch-para-observar-a-un-provider
+[statenotifierprovider]: ./state_notifier_provider

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/completed_todos.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/completed_todos.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'todo.dart';
+
+/* SNIPPET START */
+
+final completedTodosProvider = Provider<List<Todo>>((ref) {
+  // Obtenemos la lista de tareas (todos) del `todosProvider`
+  final todos = ref.watch(todosProvider);
+
+  // Devolvemos solo los `todos` completados
+  return todos.where((todo) => todo.isCompleted).toList();
+});

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -1,0 +1,36 @@
+// A provider that controls the current page
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+final pageIndexProvider = StateProvider<int>((ref) => 0);
+
+// Un provider que calcula si el usuario puede ir a la página anterior
+/* highlight-start */
+final canGoToPreviousPageProvider = Provider<bool>((ref) {
+/* highlight-end */
+  return ref.watch(pageIndexProvider) == 0;
+});
+
+class PreviousButton extends ConsumerWidget {
+  const PreviousButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Ahora estamos viendo nuestro nuevo Provider
+    // Nuestro widget ya no calcula si podemos ir a la página anterior.
+/* highlight-start */
+    final canGoToPreviousPage = ref.watch(canGoToPreviousPageProvider);
+/* highlight-end */
+
+    void goToPreviousPage() {
+      ref.read(pageIndexProvider.notifier).update((state) => state - 1);
+    }
+
+    return ElevatedButton(
+      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      child: const Text('previous'),
+    );
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/todo.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/todo.dart
@@ -1,0 +1,24 @@
+// ignore_for_file: avoid_positional_boolean_parameters
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+class Todo {
+  Todo(this.description, this.isCompleted);
+  final bool isCompleted;
+  final String description;
+}
+
+class TodosNotifier extends StateNotifier<List<Todo>> {
+  TodosNotifier() : super([]);
+
+  void addTodo(Todo todo) {
+    state = [...state, todo];
+  }
+  // TODO: añadir otros métodos, como "removeTodo", ...
+}
+
+final todosProvider = StateNotifierProvider<TodosNotifier, List<Todo>>((ref) {
+  return TodosNotifier();
+});

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -1,0 +1,26 @@
+// A provider that controls the current page
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+final pageIndexProvider = StateProvider<int>((ref) => 0);
+
+class PreviousButton extends ConsumerWidget {
+  const PreviousButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Si no está en la primera página, el botón anterior está activo
+    final canGoToPreviousPage = ref.watch(pageIndexProvider) == 0;
+
+    void goToPreviousPage() {
+      ref.read(pageIndexProvider.notifier).update((state) => state - 1);
+    }
+
+    return ElevatedButton(
+      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      child: const Text('previous'),
+    );
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider.mdx
@@ -1,0 +1,34 @@
+---
+title: StateNotifierProvider
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import todos from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos.dart";
+import todosConsumer from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos_consumer.dart";
+import { trimSnippet } from "../../../../../src/components/CodeSnippet";
+
+`StateNotifierProvider` es un provider que se usa para escuchar y exponer un [StateNotifier] (del paquete [state_notifier], que Riverpod reexporta).
+`StateNotifierProvider` junto con [StateNotifier] es la solución recomendada por Riverpod para administrar el estado que puede cambiar en reacción a una interacción del usuario.
+
+Normalmente se utiliza para:
+
+- exponer un estado inmutable que puede cambiar con el tiempo después de reaccionar a eventos personalizados.
+- centralizar la lógica para modificar algún estado (también conocido como "business logic") en un solo lugar, mejorando la capacidad de mantenimiento con el tiempo.
+
+Como ejemplo de uso, podríamos usar `StateNotifierProvider` para implementar una lista de tareas pendientes. 
+Hacerlo nos permitiría exponer métodos como `addTodo` para permitir que la interfaz de usuario modifique la lista 
+de todos en las interacciones del usuario:
+
+<CodeBlock>{trimSnippet(todos)}</CodeBlock>
+
+Ahora que hemos definido un `StateNotifierProvider`, 
+podemos usarlo para interactuar con la lista de `todos` en nuestra interfaz de usuario:
+
+<CodeBlock>{trimSnippet(todosConsumer)}</CodeBlock>
+
+[state_notifier]: https://pub.dev/packages/state_notifier
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[provider]: ./provider
+[futureprovider]: ./future_provider

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+// El estado de nuestro StateNotifier debe ser inmutable.
+// También podríamos usar paquetes como Freezed para ayudar con la implementación.
+@immutable
+class Todo {
+  const Todo({required this.id, required this.description, required this.completed});
+
+  // Todas las propiedades deben ser `final` en nuestra clase.
+  final String id;
+  final String description;
+  final bool completed;
+
+  // Como `Todo` es inmutable, implementamos un método que permite clonar el 
+  // `Todo` con un contenido ligeramente diferente.
+  Todo copyWith({String? id, String? description, bool? completed}) {
+    return Todo(
+      id: id ?? this.id,
+      description: description ?? this.description,
+      completed: completed ?? this.completed,
+    );
+  }
+}
+
+// La clase StateNotifier que se pasará a nuestro StateNotifierProvider.
+// Esta clase no debe exponer el estado fuera de su propiedad "estado", lo que significa 
+// ¡sin getters/propiedades públicas!
+// Los métodos públicos en esta clase serán los que permitirán
+// que la interfaz de usuario modifique el estado.
+class TodosNotifier extends StateNotifier<List<Todo>> {
+  // Inicializamos la lista de `todos` como una lista vacía
+  TodosNotifier(): super([]);
+
+  // Permitamos que la interfaz de usuario agregue todos.
+  void addTodo(Todo todo) {
+    // Ya que nuestro estado es inmutable, no podemos hacer `state.add(todo)`. 
+    // En su lugar, debemos crear una nueva lista de todos que contenga la anterior
+    // elementos y el nuevo.
+    // ¡Usar el spread operator de Dart aquí es útil!
+    state = [...state, todo];
+    // No es necesario llamar a "notifyListeners" o algo similar. Llamando a "state ="
+    // reconstruirá automáticamente la interfaz de usuario cuando sea necesario.
+  }
+
+  // Permitamos eliminar `todos`
+  void removeTodo(String todoId) {
+    // Nuevamente, nuestro estado es inmutable. Así que estamos haciendo 
+    // una nueva lista en lugar de cambiar la lista existente.
+    state = [
+      for (final todo in state)
+        if (todo.id != todoId) todo,
+    ];
+  }
+
+  // Marcamos una `todo` como completada
+  void toggle(String todoId) {
+    state = [
+      for (final todo in state)
+        // Estamos marcando solo el `todo` coincidente como completada
+        if (todo.id == todoId)
+          // Una vez más, dado que nuestro estado es inmutable, necesitamos hacer una copia 
+          // del `todo`. Estamos usando nuestro método `copyWith` implementado antes 
+          // para ayudar con eso.
+          todo.copyWith(completed: !todo.completed)
+        else
+          // otros `todos` no se modifican
+          todo,
+    ];
+  }
+}
+
+// Finalmente, estamos usando StateNotifierProvider para permitir que la  
+// interfaz de usuario interactúe con nuestra clase TodosNotifier.
+final todosProvider = StateNotifierProvider<TodosNotifier, List<Todo>>((ref) {
+  return TodosNotifier();
+});

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos_consumer.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos_consumer.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'todos.dart';
+
+/* SNIPPET START */
+
+class TodoListView extends ConsumerWidget {
+  const TodoListView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Reconstruir el widget cuando cambia la lista de `todos`
+    List<Todo> todos = ref.watch(todosProvider);
+
+    // Vamos a representar los `todos` en un ListView
+    return ListView(
+      children: [
+        for (final todo in todos)
+          CheckboxListTile(
+            value: todo.completed,
+            // Al tocar un `todo`, cambie su estado a completado
+            onChanged: (value) => ref.read(todosProvider.notifier).toggle(todo.id),
+            title: Text(todo.description),
+          ),
+      ],
+    );
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -1,0 +1,155 @@
+---
+title: StateProvider
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import product from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/product.dart";
+import productListView from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/product_list_view.dart";
+import sortProvider from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/sort_provider.dart";
+import connectedDropdown from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/connected_dropdown.dart";
+import sortedProductProvider from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/sorted_product_provider.dart";
+import updateReadTwice from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_twice.dart";
+import updateReadOnce from "!!raw-loader!/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_once.dart";
+import { trimSnippet } from "../../../../../src/components/CodeSnippet";
+
+`StateProvider` es un provider que expone una forma de modificar su estado. 
+Es una simplificación de [StateNotifierProvider], diseñada para evitar tener 
+que escribir una clase [StateNotifier] para casos de uso muy simples.
+
+`StateProvider` existe principalmente para permitir la modificación de variables **simples** por 
+parte de la interfaz de usuario. El estado de un `StateProvider` suele ser uno de los siguientes:
+
+- un enum, como un tipo de filtro 
+- un String, normalmente el contenido plano (raw) de un campo de texto 
+- un boolean, para casillas de verificación 
+- number, para paginación o campos de formulario de edad
+
+No debe usar `StateProvider` si:
+
+- su estado necesita lógica de validación
+- su estado es un objeto complejo (como una clase personalizada, List/Map, ...)
+- la lógica para modificar su estado es más avanzada que un simple `count++`.
+
+Para casos más avanzados, considere usar [StateNotifierProvider] en su lugar y cree una clase [StateNotifier].
+Si bien el boilerplate será un poco más grande, tener una clase StateNotifier 
+personalizada es fundamental para la capacidad de mantenimiento a largo plazo de su proyecto, 
+ya que centraliza la lógica del negocio de su estado en un solo lugar.
+
+
+## Ejemplo de uso: Cambiar el tipo de filtro usando un menú desplegable (dropdown)
+
+Un caso de uso del mundo real de `StateProvider` sería administrar el estado de componentes 
+de formularios simples como dropdowns/text y fields/checkboxes.
+
+En aras de la sencillez, la lista de productos que obtendremos se construirá 
+directamente en la aplicación y será la siguiente:
+
+<CodeBlock>{trimSnippet(product)}</CodeBlock>
+
+En una aplicación del mundo real, esta lista normalmente se obtendría utilizando 
+[FutureProvider] al realizar una solicitud de red (network request). La interfaz de usuario podría mostrar 
+la lista de productos haciendo lo siguiente:
+
+<CodeBlock>{trimSnippet(productListView)}</CodeBlock>
+
+Ahora que hemos terminado con la base, podemos agregar un menú desplegable (dropdown), 
+que permitirá filtrar nuestros productos ya sea por precio o por nombre.
+Para eso, usaremos [DropDownButton](https://api.flutter.dev/flutter/material/DropdownButton-class.html).
+
+```dart
+// Un enum que representa el tipo de filtro.
+enum ProductSortType {
+  name,
+  price,
+}
+
+Widget build(BuildContext context, WidgetRef ref) {
+  final products = ref.watch(productsProvider);
+  return Scaffold(
+    appBar: AppBar(
+      title: const Text('Products'),
+      actions: [
+        DropdownButton<ProductSortType>(
+          value: ProductSortType.price,
+          onChanged: (value) {},
+          items: const [
+            DropdownMenuItem(
+              value: ProductSortType.name,
+              child: Icon(Icons.sort_by_alpha),
+            ),
+            DropdownMenuItem(
+              value: ProductSortType.price,
+              child: Icon(Icons.sort),
+            ),
+          ],
+        ),
+      ],
+    ),
+    body: ListView.builder(
+      // ... 
+    ),
+  );
+}
+```
+
+Ahora que tenemos un dropdown, creemos un `StateProvider` 
+y sincronicemos el estado del dropdown con nuestro provider.
+
+Primero, vamos a crear el `StateProvider`:
+
+<CodeBlock>{trimSnippet(sortProvider)}</CodeBlock>
+
+Luego, podemos conectar este provider con nuestro dropdown haciendo:
+
+<CodeBlock>{trimSnippet(connectedDropdown)}</CodeBlock>
+
+Con esto, ahora deberíamos poder cambiar el tipo de clasificación. 
+¡Aún no tiene impacto en la lista de productos! Ahora es el momento de la parte final: 
+actualizar nuestro `productsProvider` para ordenar la lista de productos.
+
+Un componente clave para implementar esto es usar [ref.watch], para que nuestro `productsProvider` 
+obtenga el tipo de clasificación y vuelva a calcular la lista de productos cada vez que cambie 
+el tipo de clasificación.
+
+La implementación sería:
+
+<CodeBlock>{trimSnippet(sortedProductProvider)}</CodeBlock>
+
+¡Eso es todo! Este cambio es suficiente para que la interfaz de usuario vuelva a representar 
+automáticamente la lista de productos cuando cambia el tipo de clasificación. 
+
+Aquí está el ejemplo completo en Dartpad:
+
+<iframe
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
+></iframe>
+
+## Cómo actualizar el estado en función del valor anterior sin leer el provider dos veces
+
+A veces, deseamos actualizar el estado de un `StateProvider` en función del valor anterior. 
+Naturalmente, puedes terminar escribiendo:
+
+<CodeBlock>{trimSnippet(updateReadTwice)}</CodeBlock>
+
+Si bien no hay nada particularmente malo con este fragmento, la sintaxis es un poco inconveniente.
+
+Para mejorar un poco la sintaxis, podemos usar la función de actualización. Esta función 
+recibirá un callback que recibirá el estado actual y se espera que devuelva 
+el nuevo estado. Podemos usarlo para refactorizar nuestro código anterior a:
+
+<CodeBlock>{trimSnippet(updateReadOnce)}</CodeBlock>
+
+Este cambio logra el mismo efecto mejorando un poco la sintaxis.
+
+[ref.watch]: ../concepts/reading#uso-de-refwatch-para-observar-a-un-provider
+[ref.read]: ../concepts/reading#uso-de-refread-para-obtener-el-estado-de-un-provider-una-vez
+[statenotifierprovider]: ./state_notifier_provider
+[futureprovider]: ./future_provider
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[provider]: ./provider
+[asyncvalue]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue-class.html
+[future]: https://api.dart.dev/dart-async/Future-class.html
+[family]: ../concepts/modifiers/family

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/connected_dropdown.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/connected_dropdown.dart
@@ -1,0 +1,25 @@
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'dropdown.dart';
+import 'sort_provider.dart';
+
+Widget build(BuildContext context, WidgetRef ref) {
+  return AppBar(actions: [
+/* SNIPPET START */
+DropdownButton<ProductSortType>(
+  // Cuando cambia el tipo de clasificación, esto reconstruirá el dropdown 
+  // para actualizar el icono que se muestra.
+  value: ref.watch(productSortTypeProvider),
+  // Cuando el usuario interactúa con el dropdown, actualizamos el estado del provider.
+  onChanged: (value) =>
+      ref.read(productSortTypeProvider.notifier).state = value!,
+  items: [
+    // ...
+  ],
+),
+/* SNIPPET END */
+  ]);
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/dartpad_metadata.yaml
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/dartpad_metadata.yaml
@@ -1,0 +1,4 @@
+name: StateProvider
+mode: flutter
+files:
+  - name: full.dart

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,0 +1,100 @@
+// This code is distributed under the MIT License.
+// Copyright (c) 2022 Remi Rousselet.
+// You can find the original at https://github.com/rrousselGit/river_pod.
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: MyHomePage(),
+    );
+  }
+}
+
+class Product {
+  Product({required this.name, required this.price});
+
+  final String name;
+  final double price;
+}
+
+final _products = [
+  Product(name: 'iPhone', price: 999),
+  Product(name: 'cookie', price: 2),
+  Product(name: 'ps5', price: 500),
+];
+
+enum ProductSortType {
+  name,
+  price,
+}
+
+final productSortTypeProvider = StateProvider<ProductSortType>(
+  // ソートの種類 name を返します。これがデフォルトのステートとなります。
+  (ref) => ProductSortType.name,
+);
+
+final productsProvider = Provider<List<Product>>((ref) {
+  final sortType = ref.watch(productSortTypeProvider);
+  switch (sortType) {
+    case ProductSortType.name:
+      return _products.sorted((a, b) => a.name.compareTo(b.name));
+    case ProductSortType.price:
+      return _products.sorted((a, b) => a.price.compareTo(b.price));
+  }
+});
+
+class MyHomePage extends ConsumerWidget {
+  const MyHomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final products = ref.watch(productsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Products'),
+        actions: [
+          DropdownButton<ProductSortType>(
+            // ソートの種類が変わると、ドロップダウンメニューが更新されて
+            // 表示されるアイコン（メニューアイテム）が変わります。
+            value: ref.watch(productSortTypeProvider),
+            // ユーザがドロップダウンメニューを操作するとプロバイダのステートが更新されます。
+            onChanged: (value) =>
+                ref.read(productSortTypeProvider.notifier).state = value!,
+            items: const [
+              DropdownMenuItem(
+                value: ProductSortType.name,
+                child: Icon(Icons.sort_by_alpha),
+              ),
+              DropdownMenuItem(
+                value: ProductSortType.price,
+                child: Icon(Icons.sort),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: products.length,
+        itemBuilder: (context, index) {
+          final product = products[index];
+          return ListTile(
+            title: Text(product.name),
+            subtitle: Text('${product.price} \$'),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/product.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/product.dart
@@ -1,0 +1,20 @@
+import 'package:riverpod/riverpod.dart';
+
+/* SNIPPET START */
+
+class Product {
+  Product({required this.name, required this.price});
+
+  final String name;
+  final double price;
+}
+
+final _products = [
+  Product(name: 'iPhone', price: 999),
+  Product(name: 'cookie', price: 2),
+  Product(name: 'ps5', price: 500),
+];
+
+final productsProvider = Provider<List<Product>>((ref) {
+  return _products;
+});

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/product_list_view.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/product_list_view.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'product.dart';
+
+/* SNIPPET START */
+
+Widget build(BuildContext context, WidgetRef ref) {
+  final products = ref.watch(productsProvider);
+  return Scaffold(
+    body: ListView.builder(
+      itemCount: products.length,
+      itemBuilder: (context, index) {
+        final product = products[index];
+        return ListTile(
+          title: Text(product.name),
+          subtitle: Text('${product.price} \$'),
+        );
+      },
+    ),
+  );
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/sort_provider.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/sort_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'dropdown.dart';
+
+/* SNIPPET START */
+
+final productSortTypeProvider = StateProvider<ProductSortType>(
+  // Devolvemos el tipo de clasificación predeterminado, aquí `name`.
+  (ref) => ProductSortType.name,
+);

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/sorted_product_provider.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/sorted_product_provider.dart
@@ -1,0 +1,24 @@
+import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'dropdown.dart';
+import 'product.dart';
+import 'sort_provider.dart';
+
+final _products = [
+  Product(name: 'iPhone', price: 999),
+  Product(name: 'cookie', price: 2),
+  Product(name: 'ps5', price: 500),
+];
+
+/* SNIPPET START */
+
+final productsProvider = Provider<List<Product>>((ref) {
+  final sortType = ref.watch(productSortTypeProvider);
+  switch (sortType) {
+    case ProductSortType.name:
+      return _products.sorted((a, b) => a.name.compareTo(b.name));
+    case ProductSortType.price:
+      return _products.sorted((a, b) => a.price.compareTo(b.price));
+  }
+});

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_once.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_once.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+final counterProvider = StateProvider<int>((ref) => 0);
+
+class HomeView extends ConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          /* highlight-start */
+          ref.read(counterProvider.notifier).update((state) => state + 1);
+          /* highlight-end */
+        },
+      ),
+    );
+  }
+}

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_twice.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_twice.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+final counterProvider = StateProvider<int>((ref) => 0);
+
+class HomeView extends ConsumerWidget {
+  const HomeView({Key? key}): super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // Estamos actualizando el estado del valor anterior, terminamos leyendo 
+          // el provider ¡dos veces!
+          ref.read(counterProvider.notifier).state = ref.read(counterProvider.notifier).state + 1;
+        },
+      ),
+    );
+  }
+}

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -24,7 +24,7 @@
     "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
   },
   "copyright": {
-    "message": "Copyright © 2021 Remi Rousselet. <br /> Construido con Docusaurus.",
+    "message": "Copyright © 2022 Remi Rousselet. <br /> Construido con Docusaurus.",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -1,0 +1,30 @@
+{
+  "link.title.Docs": {
+    "message": "Documentación",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "Comunidad",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.Getting started": {
+    "message": "Empezar",
+    "description": "The label of footer link with label=Getting started linking to docs/getting_started"
+  },
+  "link.item.label.Stack Overflow": {
+    "message": "Stack Overflow",
+    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/flutter"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/remi_rousselet"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+  },
+  "copyright": {
+    "message": "Copyright © 2021 Remi Rousselet. <br /> Construido con Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Riverpod",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "Documentación",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
Finally, all docs are available in Spanish, this PR is the second part of PR #1106.

All recent changes/additions made to the English version are reflected like the new StateProvider.

Some minor fixes were done to code, footer and current json files.