### PR TITLE
change-background-color-of-code-block

### DIFF
--- a/website/src/components/CodeSnippet/index.tsx
+++ b/website/src/components/CodeSnippet/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react";
 import CodeBlock from "@theme/CodeBlock";
+import useThemeContext from '@theme/hooks/useThemeContext';
 
 const SKIP = "/* SKIP */";
 const SKIP_END = "/* SKIP END */";
@@ -28,9 +29,11 @@ interface CodeSnippetProps {
   snippet: string;
 }
 
-export const CodeSnippet: React.FC<CodeSnippetProps> = ({ snippet, title }) => {
+export const CodeSnippet: React.FC<CodeSnippetProps> = ({ snippet, title}) => {
+  const {isDarkTheme} = useThemeContext()
+
   return (
-    <div className="snippet">
+    <div className={`snippet ${!isDarkTheme && 'whiteCodeBlock'}`}>
       <div className="snippet__title_bar">
         <div className="snippet__dots">
           <div className="snippet__dot"></div>

--- a/website/src/components/CodeSnippet/index.tsx
+++ b/website/src/components/CodeSnippet/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, {ReactElement, useEffect, useState} from "react";
 import CodeBlock from "@theme/CodeBlock";
 import useThemeContext from '@theme/hooks/useThemeContext';
 
@@ -30,10 +30,17 @@ interface CodeSnippetProps {
 }
 
 export const CodeSnippet: React.FC<CodeSnippetProps> = ({ snippet, title}) => {
-  const {isDarkTheme} = useThemeContext()
+  const themeData = useThemeContext()
+  const [isDarkTheme, setIsDarkTheme] = useState<boolean>(true)
+
+  useEffect(() => {
+    if(themeData){
+      setTimeout(() => setIsDarkTheme(themeData.isDarkTheme), 0)
+    }
+  },[themeData])
 
   return (
-    <div className={`snippet ${!isDarkTheme && 'whiteCodeBlock'}`}>
+    <div className={`snippet ${!isDarkTheme ? 'whiteCodeBlock' : ''}`}>
       <div className="snippet__title_bar">
         <div className="snippet__dots">
           <div className="snippet__dot"></div>

--- a/website/src/components/CodeSnippet/style.scss
+++ b/website/src/components/CodeSnippet/style.scss
@@ -1,6 +1,11 @@
 .snippet {
   position: relative;
 
+  &.whiteCodeBlock  pre code {
+    background-color: white;
+  }
+
+
   &__title_bar {
     position: absolute;
     right: 0;

--- a/website/src/scss/base/_reset.scss
+++ b/website/src/scss/base/_reset.scss
@@ -42,6 +42,6 @@ section {
   max-width: 100vw;
 }
 
-pre code {
-  background-color: var(--ifm-pre-background);;
+html[data-theme=light]  pre code {
+  background-color: var(--ifm-pre-background);
 }

--- a/website/src/scss/base/_reset.scss
+++ b/website/src/scss/base/_reset.scss
@@ -41,3 +41,7 @@ main {
 section {
   max-width: 100vw;
 }
+
+pre code {
+  background-color: var(--ifm-pre-background);;
+}


### PR DESCRIPTION
currently background color of block of code in light theme is white and the page background is also white so it's hard to distinguish between code block from other parts so I change it to be different.
this is currently how it looks like

![2](https://user-images.githubusercontent.com/46605967/159310768-3ac04eac-6f21-4dbe-8337-5482256597de.PNG)

and I just change the background color to be more readable:
![1](https://user-images.githubusercontent.com/46605967/159310824-abfcdfa2-6c69-4417-9316-4cacabf1a2e6.PNG)

