### PR TITLE
Activate macos support for stackoverflow example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,18 @@ pubspec.lock
 *.freezed.dart
 !packages/*/lib/**/*.freezed.dart
 
-# Ignoring native folders of the example as they can be re-generated easily
+# Ignoring native folders of the example as they can be re-generated easily using:
+# flutter create --platforms=android,ios,web,windows,macos .
 **/example/android/
 **/example/ios/
 **/example/web/
 examples/**/android/
 examples/**/ios/
 examples/**/web/
+examples/**/windows/
 examples/**/macos/
+# Include specific entitlements files which enable internet access
+!examples/**/macos/Runner/DebugProfile.entitlements
 
 # Miscellaneous
 coverage/

--- a/examples/stackoverflow/macos/Runner/DebugProfile.entitlements
+++ b/examples/stackoverflow/macos/Runner/DebugProfile.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Needed macOS support for the SO example & required entitlement change to allow internet access.

It may be easier to enable the native platform folders instead of the doing the gitignore dance.