### PR TITLE
Add callbacks to be invoked on invalidate/refresh. #698

### DIFF
--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -258,6 +258,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   List<void Function()>? _onCancelListeners;
   List<void Function()>? _onAddListeners;
   List<void Function()>? _onRemoveListeners;
+  List<void Function()>? _onBeforeInvalidateListeners;
   List<void Function(State?, State)>? _onChangeSelfListeners;
   List<void Function(Object, StackTrace)>? _onErrorSelfListeners;
 
@@ -397,6 +398,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   void invalidateSelf() {
     if (_mustRecomputeState) return;
 
+    _onBeforeInvalidateListeners?.forEach(_runGuarded);
     _mustRecomputeState = true;
     _runOnDispose();
     _container._scheduler.scheduleProviderRefresh(this);
@@ -968,6 +970,12 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
   void onResume(void Function() cb) {
     _onResumeListeners ??= [];
     _onResumeListeners!.add(cb);
+  }
+
+  @override
+  void onBeforeInvalidate(void Function() cb) {
+    _onBeforeInvalidateListeners ??= [];
+    _onBeforeInvalidateListeners!.add(cb);
   }
 
   @override

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -119,6 +119,12 @@ abstract class Ref<State extends Object?> {
   /// - [onCancel], a life-cycle for when all listeners of a provider are removed.
   void onDispose(void Function() cb);
 
+  /// Adds a listener to perform an operation before the provider is invalidated.
+  ///
+  /// This is usually when calling [ProviderContainer.invalidate] or
+  /// [ProviderContainer.refresh].
+  void onBeforeInvalidate(void Function() cb);
+
   /// Read the state associated with a provider, without listening to that provider.
   ///
   /// By calling [read] instead of [watch], this will not cause a provider's

--- a/packages/riverpod/test/framework/provider_element_test.dart
+++ b/packages/riverpod/test/framework/provider_element_test.dart
@@ -1281,6 +1281,42 @@ void main() {
     });
   });
 
+  group('ref.onBeforeInvalidate', () {
+    test('is called on invalidate', () {
+      final container = createContainer();
+      final onBeforeInvalidate = OnBeforeInvalidateListener();
+      when(onBeforeInvalidate()).thenReturn(null);
+      final provider = Provider((ref) {
+        ref.onBeforeInvalidate(onBeforeInvalidate);
+      });
+      container.read(provider);
+      verifyZeroInteractions(onBeforeInvalidate);
+      container.invalidate(provider);
+      verify(onBeforeInvalidate()).called(1);
+      // it's already invalidated, so no more calls to the listener.
+      container.invalidate(provider);
+      verifyNoMoreInteractions(onBeforeInvalidate);
+      // not called for `dispose`.
+      container.dispose();
+      verifyNoMoreInteractions(onBeforeInvalidate);
+    });
+    test('is called on refresh', () {
+      final container = createContainer();
+      final onBeforeInvalidate = OnBeforeInvalidateListener();
+      when(onBeforeInvalidate()).thenReturn(null);
+      final provider = Provider((ref) {
+        ref.onBeforeInvalidate(onBeforeInvalidate);
+      });
+      container.read(provider);
+      verifyZeroInteractions(onBeforeInvalidate);
+      container.refresh(provider);
+      verify(onBeforeInvalidate()).called(1);
+      // a second refresh will again call the invalidate listener.
+      container.refresh(provider);
+      verify(onBeforeInvalidate()).called(2);
+    });
+  });
+
   test(
       'onDispose is triggered only once if within autoDispose unmount, a dependency chnaged',
       () async {

--- a/packages/riverpod/test/utils.dart
+++ b/packages/riverpod/test/utils.dart
@@ -71,6 +71,10 @@ class ErrorListener extends Mock {
   void call(Object? error, StackTrace? stackTrace);
 }
 
+class OnBeforeInvalidateListener extends Mock {
+  void call();
+}
+
 class Selector<Input, Output> extends Mock {
   Selector(this.fake, Output Function(Input) selector) {
     when(call(any)).thenAnswer((i) {


### PR DESCRIPTION
Allows providers to react to being disposed or refreshed. Can be used for either invalidate caches or other dependencies to enforce a true `refresh` when being recreated.