### PR TITLE
Prevent unnecessary widget re-rendering in the hooks example

### DIFF
--- a/packages/flutter_riverpod/example/lib/main.dart
+++ b/packages/flutter_riverpod/example/lib/main.dart
@@ -30,7 +30,7 @@ class Home extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Counter example')),
       body: Center(
-        // Consumer is a widget that allows you reading providers.
+        // Consumer is a builder widget that allows you to read providers.
         child: Consumer(
           builder: (context, ref, _) {
             final count = ref.watch(counterProvider);

--- a/packages/hooks_riverpod/example/lib/main.dart
+++ b/packages/hooks_riverpod/example/lib/main.dart
@@ -47,16 +47,21 @@ class MyHomePage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(counterProvider);
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('Riverpod counter example'),
       ),
       body: Center(
-        child: Text(
-          '$count',
-          style: Theme.of(context).textTheme.headlineMedium,
+        // HookConsumer is a builder widget that allows you to read providers and utitlise hooks.
+        child: HookConsumer(
+          builder: (context, ref, _) {
+            final count = ref.watch(counterProvider);
+
+            return Text(
+              '$count',
+              style: Theme.of(context).textTheme.headlineMedium,
+            );
+          },
         ),
       ),
       floatingActionButton: FloatingActionButton(


### PR DESCRIPTION
- Fix minor grammar issue
- Ensure consistency between the examples for flutter_riverpod and hooks_riverpod, as one demonstrated a more optimised approach for handling unnecessary rebuilds.