### PR TITLE
riverpod_analyzer_utils : 0.5.8 -> 0.5.9

### DIFF
--- a/packages/riverpod_analyzer_utils/CHANGELOG.md
+++ b/packages/riverpod_analyzer_utils/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased patch
+## 0.5.9 - 2025-01-08
 
 Support latest analyzer
 

--- a/packages/riverpod_analyzer_utils/pubspec.yaml
+++ b/packages/riverpod_analyzer_utils/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/rrousselGit/river_pod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
   - https://github.com/sponsors/rrousselGit/
-version: 0.5.8
+version: 0.5.9
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased patch
+## 2.6.4 - 2025-01-08
 
 Support latest analyzer
 

--- a/packages/riverpod_generator/pubspec.yaml
+++ b/packages/riverpod_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_generator
 description: A code generator for Riverpod. This both simplifies the syntax empowers it, such as allowing stateful hot-reload.
-version: 2.6.3
+version: 2.6.4
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
@@ -17,7 +17,7 @@ dependencies:
   crypto: ^3.0.2
   meta: ^1.7.0
   path: ^1.8.0
-  riverpod_analyzer_utils: 0.5.8
+  riverpod_analyzer_utils: 0.5.9
   riverpod_annotation: 2.6.1
   source_gen: ^2.0.0
 

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased patch
+## 2.6.4 - 2025-01-08
 
 Support latest analyzer
 

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_lint
 description: Riverpod_lint is a developer tool for users of Riverpod, designed to help stop common issues and simplify repetitive tasks.
-version: 2.6.3
+version: 2.6.4
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,7 +18,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.1
   riverpod: 2.6.1
-  riverpod_analyzer_utils: 0.5.8
+  riverpod_analyzer_utils: 0.5.9
   source_span: ^1.8.0
   yaml: ^3.1.1
 


### PR DESCRIPTION
riverpod_generator      : 2.6.3 -> 2.6.4
riverpod_lint           : 2.6.3 -> 2.6.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
	- Released `riverpod_analyzer_utils` version 0.5.9
	- Updated `riverpod_generator` to version 2.6.4
	- Updated `riverpod_lint` to version 2.6.4

- **Dependency Updates**
	- Upgraded `riverpod_analyzer_utils` dependency across packages to version 0.5.9

- **Changelog Updates**
	- Added release notes for version 0.5.9 and 2.6.4 in respective package changelogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->