### PR TITLE
Remove references to custom_lint and update install docs

### DIFF
--- a/.github/workflows/riverpod_lint.yml
+++ b/.github/workflows/riverpod_lint.yml
@@ -46,15 +46,8 @@ jobs:
         run: echo "PUB_CACHE="$HOME/.pub-cache"" >> $GITHUB_ENV
       - name: Install dependencies
         run: flutter pub get
-      - run: dart pub global activate custom_lint
-
       - name: Analyze
         run: flutter analyze
-
-      - name: Run custom_lint
-        run: custom_lint
-        # Workaround to https://github.com/invertase/dart_custom_lint/issues/77
-        if: matrix.package_path == 'packages/riverpod_lint_flutter_test'
 
       - name: Run tests
         run: |

--- a/analysis_options_without_plugins.yaml
+++ b/analysis_options_without_plugins.yaml
@@ -18,7 +18,7 @@ analyzer:
     # Remove once we require analyzer 8.0.0
     # We currently support both 7.0 and 8.0, so we can't migrate yet.
     deprecated_member_use: ignore
-    # Analyzer API is experimental, but kind of necessary for custom_lint plugins
+    # Analyzer API is experimental, but kind of necessary for analyzer plugins
     experimental_member_use: ignore
 
 linter:

--- a/packages/riverpod_lint/README.md
+++ b/packages/riverpod_lint/README.md
@@ -66,103 +66,30 @@ Riverpod_lint adds various warnings with quick fixes and refactoring options, su
 
 ## Installing riverpod_lint
 
-Riverpod_lint is implemented using [custom_lint]. As such, it uses custom_lint's installation logic.  
-Long story short:
+Riverpod_lint is implemented using [analysis_server_plugin]. As such, it is installed through `analysis_options.yaml`
 
-- Add both riverpod_lint and custom_lint to your `pubspec.yaml`:
-  ```yaml
-  dev_dependencies:
-    custom_lint:
-    riverpod_lint:
-  ```
-- Enable `custom_lint`'s plugin in your `analysis_options.yaml`:
-
-  ```yaml
-  analyzer:
-    plugins:
-      - custom_lint
-  ```
-
-## Enabling/disabling lints.
-
-By default when installing riverpod_lint, most of the lints will be enabled.
-To change this, you have a few options.
-
-### Disable one specific rule
-
-You may dislike one of the various lint rules offered by riverpod_lint.
-In that event, you can explicitly disable this lint rule for your project
-by modifying the `analysis_options.yaml`
+Long story short, create an `analysis_options.yaml` next to your `pubspec.yaml` and add:
 
 ```yaml
 analyzer:
   plugins:
-    - custom_lint
+    - riverpod_lint
 
-custom_lint:
-  rules:
-    # Explicitly disable one lint rule
-    - missing_provider_scope: false
-```
-
-Note that you can both enable and disable lint rules at once.
-This can be useful if your `analysis_options.yaml` includes another one:
-
-```yaml
-include: path/to/another/analysis_options.yaml
-analyzer:
-  plugins:
-    - custom_lint
-
-custom_lint:
-  rules:
-    # Enable one rule
-    - provider_parameters
-    # Disable another
-    - missing_provider_scope: false
-```
-
-### Disable all lints by default
-
-Instead of having all lints on by default and manually disabling lints of your choice,
-you can switch to the opposite logic:  
-Have lints off by default, and manually enable lints.
-
-This can be done in your `analysis_options.yaml` with the following:
-
-```yaml
-analyzer:
-  plugins:
-    - custom_lint
-
-custom_lint:
-  # Forcibly disable lint rules by default
-  enable_all_lint_rules: false
-  rules:
-    # You can now enable one specific rule in the "rules" list
-    - missing_provider_scope
+plugins:
+  riverpod_lint: <version number>
 ```
 
 ## Running riverpod_lint in the terminal/CI
 
-Custom lint rules created by riverpod_lint may not show-up in `dart analyze`.
-To fix this, you can run a custom command line: `custom_lint`.
+Once `riverpod_lint` is installed, `dart analyze` will show warnings
+from the lint rules created by riverpod_lint.
 
-Since your project should already have custom_lint installed
+Since your project should already have `riverpod_lint` installed
 (cf [installing riverpod_lint](#installing-riverpod_lint)), then you should be
 able to run:
 
 ```sh
-dart run custom_lint
-```
-
-Alternatively, you can globally install `custom_lint`:
-
-```sh
-# Install custom_lint for all projects
-dart pub global activate custom_lint
-# run custom_lint's command line in a project
-custom_lint
+dart analyze
 ```
 
 ## All the lints
@@ -771,17 +698,4 @@ class B extends _$B {
 
 ![Convert provider to functional variant sample](https://raw.githubusercontent.com/rrousselGit/riverpod/master/packages/riverpod_lint/resources/convert_to_functional_provider.gif)
 
-## Migrations
-
-Migrations are a list of warnings with an automatic quick-fix, to help
-upgrading to higher Riverpod versions.
-They are designed to be used only once.
-
-As a general rule, it is recommended to apply migration by running the following
-in your terminal:
-
-```sh
-dart run custom_lint --fix
-```
-
-[custom_lint]: https://pub.dev/packages/custom_lint
+[analysis_server_plugin]: https://pub.dev/packages/analysis_server_plugin

--- a/website/docs/introduction/getting_started.mdx
+++ b/website/docs/introduction/getting_started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-version: 7
+version: 8
 ---
 
 import Tabs from "@theme/Tabs";
@@ -95,38 +95,29 @@ dart run build_runner watch -d
 
 That's it. You've added [Riverpod] to your app!
 
-## Enabling riverpod_lint/custom_lint
+## Enabling riverpod_lint
 
 Riverpod comes with an optional [riverpod_lint]
 package that provides lint rules to help you write better code, and
 provide custom refactoring options.
 
-The package should already be installed if you followed the previous steps, but a
-separate step is necessary to enable it.
+Riverpod_lint is implemented using [analysis_server_plugin]. As such, it is installed through `analysis_options.yaml`
 
-To enable [riverpod_lint], you need to add an `analysis_options.yaml` placed next to
-your `pubspec.yaml` and include the following:
+Long story short, create an `analysis_options.yaml` next to your `pubspec.yaml` and add:
 
-<CodeBlock language="yaml" title="analysis_options.yaml">
-  {`analyzer:
+```yaml title="analysis_options.yaml"
+analyzer:
   plugins:
-    - custom_lint`}
-</CodeBlock>
+    - riverpod_lint
+
+plugins:
+  riverpod_lint: <latest version from https://pub.dev/packages/riverpod_lint>
+```
 
 You should now see warnings in your IDE if you made mistakes when using Riverpod
 in your codebase.
 
 To see the full list of warnings and refactorings, head to the [riverpod_lint] page.
-
-:::note
-Those warnings will not show-up in the `dart analyze` command.  
-If you want to check those warnings in the CI/terminal, you can run the following:
-
-```sh
-dart run custom_lint
-```
-
-:::
 
 ## Usage example: Hello world
 
@@ -183,3 +174,4 @@ If you are using `Flutter` and `Android Studio` or `IntelliJ`, consider using [F
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
 [riverpod_lint]: https://pub.dev/packages/riverpod_lint
+[analysis_server_plugin]: https://pub.dev/packages/analysis_server_plugin

--- a/website/docs/introduction/getting_started/dart_pub_add.tsx
+++ b/website/docs/introduction/getting_started/dart_pub_add.tsx
@@ -10,7 +10,7 @@ export function buildDeps({
     result += `dart pub add ${dep}\n`;
   }
 
-  for (const dep of [...devDeps, "custom_lint", "riverpod_lint"]) {
+  for (const dep of devDeps) {
     result += `dart pub add dev:${dep}\n`;
   }
 

--- a/website/docs/introduction/getting_started/dart_pubspec.tsx
+++ b/website/docs/introduction/getting_started/dart_pubspec.tsx
@@ -2,7 +2,6 @@ import {
   riverpodVersion,
   riverpodAnnotationVersion,
   riverpodGeneratorVersion,
-  riverpodLintVersion,
 } from "../../../src/versions";
 
 const codegen = `name: my_app_name
@@ -15,9 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_runner:
-  custom_lint:
   riverpod_generator: ^${riverpodGeneratorVersion}
-  riverpod_lint: ^${riverpodLintVersion}
 `;
 
 const raw = `name: my_app_name
@@ -26,10 +23,6 @@ environment:
 
 dependencies:
   riverpod: ^${riverpodVersion}
-
-dev_dependencies:
-  custom_lint:
-  riverpod_lint: ^${riverpodLintVersion}
 `;
 
 export default {

--- a/website/docs/introduction/getting_started/pub_add.tsx
+++ b/website/docs/introduction/getting_started/pub_add.tsx
@@ -5,12 +5,12 @@ export function buildDeps({
   deps?: string[];
   devDeps?: string[];
 }) {
-  var result = '';
+  var result = "";
   for (const dep of deps) {
     result += `flutter pub add ${dep}\n`;
   }
 
-  for (const dep of [...devDeps, "custom_lint", "riverpod_lint"]) {
+  for (const dep of devDeps) {
     result += `flutter pub add dev:${dep}\n`;
   }
 

--- a/website/docs/introduction/getting_started/pubspec.tsx
+++ b/website/docs/introduction/getting_started/pubspec.tsx
@@ -3,7 +3,6 @@ import {
   hooksRiverpodVersion,
   riverpodAnnotationVersion,
   riverpodGeneratorVersion,
-  riverpodLintVersion,
 } from "../../../src/versions";
 
 function plain(riverpod: string) {
@@ -16,10 +15,6 @@ dependencies:
   flutter:
     sdk: flutter
   ${riverpod}
-
-dev_dependencies:
-  custom_lint:
-  riverpod_lint: ^${riverpodLintVersion}
 `;
 }
 
@@ -37,9 +32,7 @@ dependencies:
 
 dev_dependencies:
   build_runner:
-  custom_lint:
   riverpod_generator: ^${riverpodGeneratorVersion}
-  riverpod_lint: ^${riverpodLintVersion}
 `;
 }
 
@@ -47,5 +40,7 @@ export default {
   raw: plain(`flutter_riverpod: ^${flutterRiverpodVersion}`),
   hooks: plain(`hooks_riverpod: ^${hooksRiverpodVersion}\n  flutter_hooks:`),
   codegen: codegen(`flutter_riverpod: ^${flutterRiverpodVersion}`),
-  hooksCodegen: codegen(`hooks_riverpod: ^${hooksRiverpodVersion}\n  flutter_hooks:`),
+  hooksCodegen: codegen(
+    `hooks_riverpod: ^${hooksRiverpodVersion}\n  flutter_hooks:`
+  ),
 };

--- a/website/docs/tutorials/first_app.mdx
+++ b/website/docs/tutorials/first_app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Your first Riverpod app
-version: 1
+version: 2
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -125,18 +125,17 @@ This will add the latest version of Riverpod to your project, along with Dio.
 To help you write better Riverpod code, you can install the [riverpod_lint] package.  
 This package provides a set of refactors to more easily write Riverpod code, as well as a set of lints to help you avoid common mistakes.
 
-You can install it by running the following command:
+Riverpod_lint is implemented using [analysis_server_plugin]. As such, it is installed through `analysis_options.yaml`
 
-```sh
-flutter pub add --dev riverpod_lint custom_lint
-```
+Long story short, create an `analysis_options.yaml` next to your `pubspec.yaml` and add:
 
-Then, you can enable it by updating the `analysis_options.yaml` file next to your `pubspec.yaml` to include the following:
-
-```yaml
+```yaml title="analysis_options.yaml"
 analyzer:
   plugins:
-    - custom_lint
+    - riverpod_lint
+
+plugins:
+  riverpod_lint: <latest version from https://pub.dev/packages/riverpod_lint>
 ```
 
 ### Adding ProviderScope in our main function
@@ -504,3 +503,4 @@ Notice how we never had to write a `try/catch` or write code such as `isLoading 
 [AsyncValue.isRefreshing]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/AsyncValueX/isRefreshing.html
 [riverpod_lint]: https://pub.dev/packages/riverpod_lint
 [ProviderScope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[analysis_server_plugin]: https://pub.dev/packages/analysis_server_plugin

--- a/website/src/versions.js
+++ b/website/src/versions.js
@@ -3,12 +3,12 @@ import flutterRiverpodPubspec from "!!raw-loader!../../packages/flutter_riverpod
 import hooksRiverpodPubspec from "!!raw-loader!../../packages/hooks_riverpod/pubspec.yaml";
 import riverpodAnnotationPubspec from "!!raw-loader!../../packages/riverpod_annotation/pubspec.yaml";
 import riverpodGeneratorPubspec from "!!raw-loader!../../packages/riverpod_generator/pubspec.yaml";
-import riverpodLintPubspec from "!!raw-loader!../../packages/riverpod_lint/pubspec.yaml";
 import { parse } from "yaml";
 
 export const riverpodVersion = parse(riverpodPubspec).version;
 export const flutterRiverpodVersion = parse(flutterRiverpodPubspec).version;
 export const hooksRiverpodVersion = parse(hooksRiverpodPubspec).version;
 export const riverpodGeneratorVersion = parse(riverpodGeneratorPubspec).version;
-export const riverpodAnnotationVersion = parse(riverpodAnnotationPubspec).version;
-export const riverpodLintVersion = parse(riverpodLintPubspec).version;
+export const riverpodAnnotationVersion = parse(
+  riverpodAnnotationPubspec
+).version;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Riverpod lint setup instructions to use analysis_options.yaml configuration instead of CLI-based installation.
  * Bumped documentation versions in getting started and tutorial guides.

* **Chores**
  * Removed custom_lint from CI workflow and dependencies.
  * Removed custom_lint references from build configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->