### PR TITLE
fix: reset _didChangeDependency flag properly in invalidateSelf

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed a bug with scoping when specifying `dependencies: [...]`
 - Added `Override.origin`. This enables knowing which provider is associated with an override.
 - Fix a regression with `AsyncLoading.isRefreshing/isReloading`
+- Fix retry counter resetting infinitely when calling `invalidate(asReload: true)` multiple times
 
 ## 3.0.3 - 2025-10-09
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -736,7 +736,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
   }
 
   void invalidateSelf({required bool asReload}) {
-    if (asReload) _didChangeDependency = true;
+    _didChangeDependency = asReload;
     if (_mustRecomputeState) return;
 
     _mustRecomputeState = true;


### PR DESCRIPTION
## Summary

Fixes #4441

The `invalidateSelf` method was only setting `_didChangeDependency = true` when `asReload` was true, but never resetting it to false when `asReload` was false.

This caused a bug where calling `invalidate(asReload: true)` multiple times during retry would cause the retry counter to reset infinitely, because `_didChangeDependency` remained true from the previous call.

### The Bug Flow

```
1. invalidateSelf(asReload: true) called
   → _didChangeDependency = true

2. buildState() errors before reaching _didChangeDependency = false
   → _didChangeDependency is still true

3. triggerRetry() → Timer → invalidateSelf(asReload: false)
   → if (false) _didChangeDependency = true; // not executed
   → _didChangeDependency is still true! (problem)

4. buildState() runs again
   → if (_didChangeDependency) _retryCount = 0;  // reset!
   → retry forever: 0, 1, 0, 1, 0, 1...
```

### The Fix

```dart
// Before
if (asReload) _didChangeDependency = true;

// After  
_didChangeDependency = asReload;
```

This ensures that when retry calls `invalidateSelf(asReload: false)`, the flag is properly set to false.

## Test plan

- [x] Added test case: `second invalidate with asReload:true should not cause infinite retry reset`
- [ ] Existing retry tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry/invalidation behavior during reloads: the retry counter reliably resets on reload invalidation and then progresses correctly, preventing unintended infinite retry loops.

* **Tests**
  * Added a test that repeats reload invalidation to verify the retry-reset behavior remains stable.

* **Documentation**
  * Noted the fix in the changelog under Unreleased minor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->