### PR TITLE
Fix grammar and sentence struct in caution message about select usage

### DIFF
--- a/website/docs/how_to/select.mdx
+++ b/website/docs/how_to/select.mdx
@@ -48,7 +48,7 @@ Returning a `List` and then mutating that list will not trigger a rebuild.
 
 :::caution
 Using `select` slightly slows down individual read operations and
-increase a tiny bit the complexity of your code.  
+increases the complexity of your code by a tiny bit.
 It may not be worth using it if those "other properties"
 rarely change.
 :::


### PR DESCRIPTION
## Related Issues

fixes #your-issue-number

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in instructional documentation through grammar and phrasing refinements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->