### PR TITLE
feat: add copyWith to AsyncValue for easier state manipulation

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- feat: Added copyWith to AsyncValue to simplify state transitions and optimistic updates.
+
 ## 3.2.0 - 2026-01-17
 
 - Added missing `weak` flags to `WidgetRef.listen/listenManual`

--- a/packages/riverpod/lib/src/core/async_value.dart
+++ b/packages/riverpod/lib/src/core/async_value.dart
@@ -634,16 +634,23 @@ sealed class AsyncValue<ValueT> {
     Object? value = _sentinel,
     Object? error = _sentinel,
     Object? stackTrace = _sentinel,
+    bool clearValue = false,
   }) {
     final newIsLoading = isLoading ?? this.isLoading;
 
     final bool hasNewValue;
     final ValueT? newValue;
-    if (value == _sentinel) {
+    if (clearValue) {
+      hasNewValue = false;
+      newValue = null;
+    } else if (value == _sentinel) {
       hasNewValue = hasValue;
       newValue = this.value;
     } else if (value == null) {
-      hasNewValue = false;
+      // This path is reached if the user explicitly passed `value: null`.
+      // In that case, we set the value to null (if T is nullable).
+      // We do NOT clear the value (make hasValue false).
+      hasNewValue = true;
       newValue = null;
     } else {
       hasNewValue = true;

--- a/packages/riverpod/test/src/core/async_value_test.dart
+++ b/packages/riverpod/test/src/core/async_value_test.dart
@@ -1781,12 +1781,33 @@ void main() {
         const AsyncLoading<int>(),
         isRefresh: false,
       );
-      // data is AsyncData with isReloading=true (if implemented that way? No, copyWithPrevious logic)
-      // Actually copyWithPrevious on AsyncData returns AsyncData.
 
-      // Let's test that copyWith preserves previous value's properties if not overridden.
-      // But copyWith creates new instances.
-      // We mainly care about value/error/loading.
+      expect(data.isReloading, true);
+      expect(data.valueFilled?.kind, DataKind.live);
+      expect(data.valueFilled?.source, DataSource.reload);
+
+      final copy = data.copyWith(isLoading: false);
+
+      expect(copy.isReloading, true);
+      expect(copy.valueFilled?.kind, DataKind.live);
+      expect(copy.valueFilled?.source, DataSource.reload);
+    });
+
+    test('copyWith(value: null) sets value to null', () {
+      const data = AsyncData<int?>(42);
+      final copy = data.copyWith(value: null);
+
+      expect(copy.hasValue, true);
+      expect(copy.value, null);
+    });
+
+    test('copyWith(clearValue: true) clears value', () {
+      const data = AsyncData<int>(42);
+      final copy = data.copyWith(clearValue: true, isLoading: true);
+
+      expect(copy.hasValue, false);
+      expect(copy.value, null);
+      expect(copy.isLoading, true);
     });
 
     test('throws if invalid state', () {


### PR DESCRIPTION
### Context
While working on features that require optimistic UI updates or manual state toggling, I've found that using `copyWithPrevious` or manually mapping through `when`/`map` can feel a bit clunky for simple changes. 

For instance, when we want to keep the current data but briefly trigger a loading state (e.g., a "refresh" or "re-fetch" trigger in the UI), we currently have to reconstruct the state manually. This PR introduces a standard `copyWith` method to `AsyncValue` to streamline these quality-of-life improvements.

### Changes
I've implemented `copyWith` using a **Sentinel pattern** to ensure we can distinguish between an argument being `null` (intent to clear the field) versus an argument not being passed at all (intent to preserve the current value).

- **Strict Precedence:** The logic respects the Riverpod hierarchy: `Loading > Error > Data`.
- **Metadata Preservation:** It correctly carries over `DataKind` and `DataSource` where applicable, ensuring the internal state remains consistent.
- **Support for explicit nulls:** You can explicitly clear an error or value by passing `null`.

### Usage Example
```dart
// Keep existing data but toggle loading (Optimistic UI)
state = state.copyWith(isLoading: true);

// Update data and stop loading in one go
state = state.copyWith(
  value: newData,
  isLoading: false,
  error: null,
); 
```

I added a new test group in `async_value_test.dart` covering:
Transitioning between all `AsyncValue` subtypes via `copyWith`.
Verification of the Sentinel logic (explicit nulls vs. omitted arguments).
Edge cases regarding stack trace resets when errors are updated.
All existing core tests were verified to ensure no regressions were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AsyncValue.copyWith() to create modified AsyncValue instances by selectively updating loading state, value, error, and stack trace; distinguishes intentional nulls from unchanged fields, supports clearing values, and enforces valid state combinations.

* **Tests**
  * Added unit tests covering copyWith transitions across data/loading/error states, field preservation/clearing, stack trace behavior, and invalid-state handling.

* **Changelog**
  * Recorded copyWith in the Unreleased changelog section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->