### PR TITLE
Fix doc typo

### DIFF
--- a/packages/riverpod/lib/src/core/async_value.dart
+++ b/packages/riverpod/lib/src/core/async_value.dart
@@ -407,7 +407,7 @@ class AsyncValueIsLoadingException implements Exception {
 ///
 /// ```dart
 /// Widget build(BuildContext context, WidgetRef ref) {
-///   // Reading .requireValue will be throw both on loading and error states.
+///   // Reading .requireValue will be thrown both on loading and error states.
 ///   final User user = ref.watch(userProvider).requireValue;
 ///
 ///   ...


### PR DESCRIPTION
Fix a typo in the `requireValue` example

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected AsyncValue docs: example now references the actual API method `requireValue` (typo fixed). No functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->