### PR TITLE
Fix setState() called after dispose() in UncontrolledProviderScope

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Fixed `setState() called after dispose()` error in `UncontrolledProviderScope` when used in scrollable lists (thanks to @itsatifsiddiqui)
+
 ## 3.2.1 - 2026-02-03
 
 - Fixed a bug where resuming a paused provider could cause it to never

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -362,7 +362,9 @@ To fix this problem, you have one of two solutions:
     /// This is for scoped providers to correctly update without causing a
     /// markNeedsBuild error.
     WidgetsBinding.instance.scheduleFrameCallback(scheduleNewFrame: false, (_) {
-      setState(() {});
+      if (mounted) {
+        setState(() {});
+      }
     });
 
     return _UncontrolledProviderScope(


### PR DESCRIPTION
## Related Issues

fixes #4661

## Description

This PR fixes the `setState() called after dispose()` error that occurs when `ProviderScope` instances are used in scrollable lists (e.g., `ListView.builder`, `SliverList`).

### Root Cause
The `_UncontrolledProviderScopeState.build()` method schedules a frame callback without checking if the widget is still mounted:

```dart
WidgetsBinding.instance.scheduleFrameCallback(scheduleNewFrame: false, (_) {
  setState(() {});
});
```

When scrolling quickly, widgets get disposed but the scheduled callbacks still fire, causing the error.

### Solution
Added a mounted check before calling `setState()`:

```dart
WidgetsBinding.instance.scheduleFrameCallback(scheduleNewFrame: false, (_) {
  if (mounted) {
    setState(() {});
  }
});
```

### Testing
Tested in a production Flutter app with:
- `ListView.builder` containing widgets wrapped in `ProviderScope`
- No more `setState() called after dispose()` errors

## Checklist

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix

  - Fixed \`setState() called after dispose()\` error in \`UncontrolledProviderScope\` when used in scrollable lists (thanks to @itsatifsiddiqui)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
      *(Not applicable - this is a bug fix with no behavior changes)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed "setState() called after dispose()" error that occurred when using UncontrolledProviderScope within scrollable lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->