### PR TITLE
docs(riverpod_lint): fix broken family documentation link

### DIFF
--- a/packages/riverpod_lint/README.md
+++ b/packages/riverpod_lint/README.md
@@ -25,7 +25,7 @@ issues and simplify repetitive tasks.
 Riverpod_lint adds various warnings with quick fixes and refactoring options, such as:
 
 - Warn if `runApp` does not include a `ProviderScope` at its root
-- Warn if provider parameters do not respect [the rules of `family`](https://riverpod.dev/docs/concepts/modifiers/family#passing-multiple-parameters-to-a-family)
+- Warn if provider parameters do not respect [the rules of `family`](https://riverpod.dev/docs/concepts2/family)
 - Refactor a widget to a ConsumerWidget/ConsumerStatefulWidget
 - ...
 


### PR DESCRIPTION
The link to the `family` provider documentation in
packages/riverpod_lint/README.md points to:

https://riverpod.dev/docs/concepts/modifiers/family#passing-multiple-parameters-to-a-family

This path currently returns a 404.

This PR updates the link to the correct documentation page:

https://riverpod.dev/docs/concepts2/family

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link for Riverpod family rules to reflect current guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->