### PR TITLE
Added `disposeNotifier` flag

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased minor
+
+- Added `ChangeNotifierProvider(disposeNotifier: false)`, to disable the automatic
+  disposal of the created `ChangeNotifier`. This enables simpler migration from `pkg:provider` to `pkg:riverpod`
+  when a `ChangeNotifier` is reused between multiple providers.
+
 ## 3.2.1 - 2026-02-03
 
 - Fixed a bug where resuming a paused provider could cause it to never
@@ -1505,4 +1511,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/flutter_riverpod/lib/src/builders.dart
+++ b/packages/flutter_riverpod/lib/src/builders.dart
@@ -236,6 +236,7 @@ final class ChangeNotifierProviderFamilyBuilder {
     Iterable<ProviderOrFamily>? dependencies,
     Retry? retry,
     bool isAutoDispose = false,
+    bool disposeNotifier = true,
   }) {
     return ChangeNotifierProviderFamily<NotifierT, ArgT>(
       create,
@@ -243,6 +244,7 @@ final class ChangeNotifierProviderFamilyBuilder {
       isAutoDispose: isAutoDispose,
       dependencies: dependencies,
       retry: retry,
+      disposeNotifier: disposeNotifier,
     );
   }
 

--- a/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
@@ -79,6 +79,7 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
     super.dependencies,
     super.isAutoDispose = false,
     super.retry,
+    this.disposeNotifier = true,
   }) : super(
          $allTransitiveDependencies: computeAllTransitiveDependencies(
            dependencies,
@@ -99,6 +100,7 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
     super.from,
     super.argument,
     super.retry,
+    required this.disposeNotifier,
   });
 
   /// {@macro riverpod.autoDispose}
@@ -106,6 +108,14 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
 
   /// {@macro riverpod.family}
   static const family = ChangeNotifierProviderFamilyBuilder();
+
+  /// Whether to automatically call [ChangeNotifier.dispose] on the created [ChangeNotifier].
+  ///
+  /// This is `true` by default.
+  ///
+  /// Disabling this may be useful if you want to share a [ChangeNotifier]
+  /// across multiple providers.
+  final bool disposeNotifier;
 
   /// Obtains the [ChangeNotifier] associated with this provider, without listening
   /// to state changes.
@@ -141,6 +151,43 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
   ) {
     return _ChangeNotifierProviderElement<NotifierT>._(pointer);
   }
+
+  @override
+  ChangeNotifierProvider<NotifierT> $view({required Create<NotifierT> create}) {
+    return _View<NotifierT>(this, create);
+  }
+}
+
+final class _View<NotifierT extends ChangeNotifier?>
+    extends ChangeNotifierProvider<NotifierT> {
+  /// Implementation detail of `riverpod_generator`.
+  /// Do not use, as this can be removed at any time.
+  _View(this._inner, Create<NotifierT> _createOverride)
+    : super.internal(
+        _createOverride,
+        name: _inner.name,
+        from: _inner.from,
+        argument: _inner.argument,
+        dependencies: _inner.dependencies,
+        $allTransitiveDependencies: _inner.$allTransitiveDependencies,
+        isAutoDispose: _inner.isAutoDispose,
+        retry: _inner.retry,
+        disposeNotifier: _inner.disposeNotifier,
+      );
+
+  final ChangeNotifierProvider<NotifierT> _inner;
+
+  /// @nodoc
+  @internal
+  @override
+  _ChangeNotifierProviderElement<NotifierT> $createElement(
+    $ProviderPointer pointer,
+  ) {
+    return _inner.$createElement(pointer)..provider = this;
+  }
+
+  @override
+  String? debugGetCreateSourceHash() => _inner.debugGetCreateSourceHash();
 }
 
 /// The element of [ChangeNotifierProvider].
@@ -179,7 +226,8 @@ class _ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
     _removeListener = null;
 
     final notifier = _notifierNotifier.result?.value;
-    if (notifier != null) {
+    if (notifier != null &&
+        (provider as ChangeNotifierProvider).disposeNotifier) {
       container.runGuarded(notifier.dispose);
     }
     _notifierNotifier.result = null;
@@ -215,8 +263,30 @@ final class ChangeNotifierProviderFamily<
     super.dependencies,
     super.isAutoDispose = false,
     super.retry,
+    bool disposeNotifier = true,
   }) : super(
-         providerFactory: ChangeNotifierProvider.internal,
+         providerFactory: (
+           create, {
+           required $allTransitiveDependencies,
+           required argument,
+           required dependencies,
+           required from,
+           required isAutoDispose,
+           required name,
+           required retry,
+         }) {
+           return ChangeNotifierProvider<NotifierT>.internal(
+             create,
+             disposeNotifier: disposeNotifier,
+             name: name,
+             dependencies: dependencies,
+             $allTransitiveDependencies: $allTransitiveDependencies,
+             isAutoDispose: isAutoDispose,
+             argument: argument,
+             from: from,
+             retry: retry,
+           );
+         },
          $allTransitiveDependencies: computeAllTransitiveDependencies(
            dependencies,
          ),

--- a/packages/flutter_riverpod/test/providers/change_notifier/change_notifier_provider_test.dart
+++ b/packages/flutter_riverpod/test/providers/change_notifier/change_notifier_provider_test.dart
@@ -5,10 +5,36 @@ import 'dart:async';
 import 'package:flutter/widgets.dart' hide Listener;
 import 'package:flutter_riverpod/src/internals.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
+import '../../provider_test.dart';
 import '../../utils.dart';
 
 void main() {
+  test('Can specify disposeNotifier', () {
+    final onDispose = OnDisposeMock();
+    final notifier = DelegateNotifier(onDispose: onDispose.call);
+    final onDispose2 = OnDisposeMock();
+    final notifier2 = DelegateNotifier(onDispose: onDispose.call);
+    final container = ProviderContainer.test();
+    final provider = ChangeNotifierProvider(
+      (_) => notifier,
+      disposeNotifier: false,
+    );
+    final family = ChangeNotifierProvider.family(
+      (ref, int arg) => notifier2,
+      disposeNotifier: false,
+    );
+
+    container.read(provider);
+    container.refresh(provider);
+    verifyNever(onDispose.call());
+
+    container.read(family(0));
+    container.refresh(family(0));
+    verifyNever(onDispose2.call());
+  });
+
   test('Guards ChangeNotifier.dispose', () {
     final notifier = DelegateNotifier(
       onDispose: () => throw StateError('called'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `disposeNotifier` parameter to ChangeNotifierProvider (defaults to `true`). Set to `false` to prevent automatic disposal of notifiers, enabling shared ChangeNotifiers across multiple providers and simplifying migration paths from provider-based architectures.

* **Tests**
  * Added test coverage for the new disposal control functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->