### PR TITLE
docs: update broken links

### DIFF
--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -191,7 +191,7 @@ targets:
           provider_name_strip_pattern: "Notifier$" # (default)
 ```
 
-[family]: https://riverpod.dev/docs/concepts/modifiers/family
+[family]: https://riverpod.dev/docs/concepts2/family
 [provider]: https://github.com/rrousselGit/provider
 [riverpod]: https://github.com/rrousselGit/riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/src/data/features.tsx
+++ b/website/src/data/features.tsx
@@ -43,10 +43,10 @@ export const features: IFeatureProps[] = [
           br: <br></br>,
           Provider: (
             <code>
-              <a href={"./docs/concepts/combining_providers"}>Provider</a>
+              <a href={"./docs/concepts2/providers"}>Provider</a>
             </code>
           ),
-          families: <a href={"./docs/concepts/modifiers/family"}>"families"</a>,
+          families: <a href={"./docs/concepts2/family"}>"families"</a>,
           build: <code>build</code>,
           truly: <strong>truly</strong>,
         }}


### PR DESCRIPTION
The [homepage](https://riverpod.dev/) still links to the old concepts routes:

  - /docs/concepts/combining_providers
  - /docs/concepts/modifiers/family

  Both routes now return 404. This updates the links to the current Riverpod 3.0 docs:

  - /docs/concepts2/providers
  - /docs/concepts2/family

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links in the features/homepage content to point to the newest concept pages.
  * Updated the README reference link for the family modifier to the corresponding new documentation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->